### PR TITLE
fix(timepicker): add form item style to host (#2290)

### DIFF
--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -83,6 +83,11 @@ export class TimePicker implements ControlValueAccessor {
 
 	@Output() valueChange: EventEmitter<string> = new EventEmitter();
 
+	/**
+	 * Ensures component is properly styled when used standalone.
+	 */
+	@HostBinding("class.bx--form-item") timepickerClass = true;
+
 	writeValue(value: string) {
 		this.value = value;
 	}


### PR DESCRIPTION
Hello there,

This pull request contains the suggestion I outlined in the linked issue regarding the `ibm-timepicker` component appearing odd when used standalone.

#### Changelog

**New**

* N/A

**Changed**

* `ibm-timepicker` applies a form item class on its host element (nb. isn't thought to affect existing usages that wrap the component with the same form item class)

**Removed**

* N/A

---

Closes #2290