### PR TITLE
feat: Add progress bar component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export * from "carbon-components-angular/notification";
 export * from "carbon-components-angular/number-input";
 export * from "carbon-components-angular/pagination";
 export * from "carbon-components-angular/placeholder";
+export * from "carbon-components-angular/progress-bar";
 export * from "carbon-components-angular/progress-indicator";
 export * from "carbon-components-angular/radio";
 export * from "carbon-components-angular/search";

--- a/src/progress-bar/index.ts
+++ b/src/progress-bar/index.ts
@@ -1,0 +1,2 @@
+export * from "./progress-bar.component";
+export * from "./progress-bar.module";

--- a/src/progress-bar/package.json
+++ b/src/progress-bar/package.json
@@ -1,0 +1,7 @@
+{
+	"ngPackage": {
+		"lib": {
+			"entryFile": "index.ts"
+		}
+	}
+}

--- a/src/progress-bar/progress-bar.component.spec.ts
+++ b/src/progress-bar/progress-bar.component.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { Component, DebugElement, Input } from "@angular/core";
+import { By } from "@angular/platform-browser";
+
+import { ProgressBar } from "./";
+
+@Component({
+	template: `
+		<ibm-progress-bar
+			[label]="label"
+			[helperText]="helperText"
+			[max]="max"
+			[size]="size"
+			[status]="status"
+			[type]="type"
+			[value]="value">
+		</ibm-progress-bar>
+		`
+})
+class TestProgessBarComponent {
+	@Input() label = "Label";
+	@Input() helperText = "helper text";
+	@Input() max = 100;
+	@Input() size: "small" | "big" = "big";
+	@Input() status: "active" | "finished" | "error" = "active";
+	@Input() type: "default" | "inline" | "indented" = "default";
+	@Input() value: undefined | number = 100;
+}
+
+describe("Progress bar", () => {
+	let fixture: ComponentFixture<TestProgessBarComponent>;
+	let component: TestProgessBarComponent;
+	let element: DebugElement;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			declarations: [TestProgessBarComponent, ProgressBar]
+		});
+		fixture = TestBed.createComponent(TestProgessBarComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+		element = fixture.debugElement.query(By.css("ibm-progress-bar"));
+	});
+
+	it("should create a progress bar component", () => {
+		expect(component).toBeTruthy();
+		expect(element).not.toBeNull();
+		expect(element.nativeElement.className.includes("bx--progress-bar")).toBeTruthy();
+	});
+
+	it("should create an indeterminate progress bar when value is undefined & status is active", () => {
+		component.value = undefined;
+		component.status = "active";
+		fixture.detectChanges();
+		expect(element.nativeElement.className.includes("bx--progress-bar--indeterminate")).toBeTruthy();
+	});
+
+	it("should set the appropriate status class", () => {
+		component.status = "finished";
+		fixture.detectChanges();
+		expect(element.nativeElement.className.includes("bx--progress-bar--finished")).toBeTruthy();
+		component.status = "error";
+		fixture.detectChanges();
+		expect(element.nativeElement.className.includes("bx--progress-bar--error")).toBeTruthy();
+	});
+
+	it("should set the the correct size class", () => {
+		expect(element.nativeElement.className.includes("bx--progress-bar--big")).toBeTruthy();
+		component.size = "small";
+		fixture.detectChanges();
+		expect(element.nativeElement.className.includes("bx--progress-bar--small")).toBeTruthy();
+	});
+});

--- a/src/progress-bar/progress-bar.component.ts
+++ b/src/progress-bar/progress-bar.component.ts
@@ -1,0 +1,148 @@
+import {
+	Component,
+	HostBinding,
+	Input,
+	TemplateRef
+} from "@angular/core";
+
+@Component({
+	selector: "ibm-progress-bar",
+	template: `
+		<div
+			*ngIf="label"
+			class="bx--progress-bar__label"
+			[id]="id">
+			<span class="bx--progress-bar__label-text">
+				<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
+				<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
+			</span>
+			<svg
+				*ngIf="isFinished"
+				fill="currentColor"
+				ibmIcon="checkmark--filled"
+				class="bx--progress-bar__status-icon">
+			</svg>
+			<svg
+				*ngIf="isError"
+				fill="currentColor"
+				ibmIcon="error--filled"
+				class="bx--progress-bar__status-icon">
+			</svg>
+		</div>
+		<div
+			class="bx--progress-bar__track"
+			role="progressbar"
+			[attr.aria-invalid]="isError"
+			[attr.labelledby]="id"
+			[attr.describedby]="helperText ? helperId: null"
+			[attr.aria-valuemin]="!indeterminate ? 0 : null"
+			[attr.aria-valuemax]="!indeterminate ? max : null"
+			[attr.aria-valuenow]="!indeterminate ? value : null">
+			<div
+				class="bx--progress-bar__bar"
+				[ngStyle]="{
+					'transform': !isFinished && !isError ? percentage : null
+				}">
+			</div>
+		</div>
+		<div
+			[id]="helperId"
+			*ngIf="helperText"
+			class="bx--progress-bar__helper-text">
+			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
+		</div>
+	`
+})
+
+export class ProgressBar {
+	/**
+	 * Current value
+	 */
+	@Input() set value(num: number | undefined) {
+		this._value = num;
+		// Validate number
+		if (num > this.max) {
+			this._value = this.max;
+		}
+		if (num < 0) {
+			this._value = 0;
+		}
+		// Set values based on current state
+		if (this.isError) {
+			this._value = 0;
+		} else if (this.isFinished) {
+			this._value = this.max;
+		}
+	}
+
+	get value() {
+		return this._value;
+	}
+
+	get percentage() {
+		return `scaleX(${this.value / this.max})`;
+	}
+	// Size
+	@HostBinding("class.bx--progress-bar--big") get bigBar() {
+		return this.size === "big";
+	}
+	@HostBinding("class.bx--progress-bar--small") get smallBar() {
+		return this.size === "small";
+	}
+	// Type
+	@HostBinding("class.bx--progress-bar--default") get defaultType() {
+		return this.type === "default";
+	}
+	@HostBinding("class.bx--progress-bar--indented") get indentedType() {
+		return this.type === "indented";
+	}
+	@HostBinding("class.bx--progress-bar--inline") get inlineType() {
+		return this.type === "inline";
+	}
+	// Status
+	@HostBinding("class.bx--progress-bar--finished") get isFinished() {
+		return this.status === "finished";
+	}
+	@HostBinding("class.bx--progress-bar--error") get isError() {
+		return this.status === "error";
+	}
+	@HostBinding("class.bx--progress-bar--indeterminate") get indeterminate() {
+		return this.value === undefined && !this.isFinished && !this.isError;
+	}
+	static progressBarCounter = 0;
+
+	@Input() id = `progress-bar-${ProgressBar.progressBarCounter++}`;
+	helperId = `progress-bar-helper-${ProgressBar.progressBarCounter}`;
+	/**
+	 * Description of the progress bar
+	 */
+	@Input() label: string | TemplateRef<any>;
+	/**
+	 * Current progress textual representation
+	 */
+	@Input() helperText: string | TemplateRef<any>;
+	/**
+	 * Maximum value
+	 */
+	@Input() max = 100;
+	/**
+	 * Alignment variant of the progress bar, default is `default`
+	 */
+	@Input() type: "default" | "inline" | "indented" = "default";
+	/**
+	 * Current status of the progress bar, default is `active`
+	 */
+	@Input() status: "active" | "finished" | "error" = "active";
+	/**
+	 * Size of the progress bar, default is `big`
+	 */
+	@Input() size: "small" | "big" = "big";
+
+	@HostBinding("class.bx--progress-bar") defaultClass = true;
+	private _value = undefined;
+
+	isTemplate(value) {
+		return value instanceof TemplateRef;
+	}
+}

--- a/src/progress-bar/progress-bar.module.ts
+++ b/src/progress-bar/progress-bar.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+
+import { ProgressBar } from "./progress-bar.component";
+import { IconModule } from "carbon-components-angular/icon";
+
+@NgModule({
+	declarations: [
+		ProgressBar
+	],
+	exports: [
+		ProgressBar
+	],
+	imports: [
+		CommonModule,
+		IconModule
+	]
+})
+export class ProgressBarModule { }

--- a/src/progress-bar/progress-bar.stories.ts
+++ b/src/progress-bar/progress-bar.stories.ts
@@ -1,0 +1,61 @@
+import { storiesOf, moduleMetadata } from "@storybook/angular";
+import { withKnobs, select, text, number } from "@storybook/addon-knobs/angular";
+
+import { ProgressBarModule } from "./progress-bar.module";
+import { DocumentationModule } from "../documentation-component/documentation.module";
+
+storiesOf("Components|Progress bar", module)
+	.addDecorator(
+		moduleMetadata({
+			imports: [
+				ProgressBarModule,
+				DocumentationModule
+			]
+		})
+	)
+	.addDecorator(withKnobs)
+	.add("Basic", () => ({
+		template: `
+			<ibm-progress-bar
+				[label]="label"
+				[helperText]="helperText"
+				[max]="max"
+				[size]="size"
+				[status]="status"
+				[type]="type"
+				[value]="value">
+			</ibm-progress-bar>
+		`,
+		props: {
+			label: text("Label", "Progress bar label"),
+			helperText: text("Helper text", "Optional helper text"),
+			max: number("max", 100),
+			size: select("Size", ["big", "small"], "big"),
+			status: select("Status", ["active", "finished", "error"], "active"),
+			type: select("Type", ["default", "inline", "indented"], "default"),
+			value: number("Current value", 35)
+		}
+	}))
+	.add("Indeterminate", () => ({
+		template: `
+			<ibm-progress-bar
+				[label]="label"
+				[helperText]="helperText"
+				[size]="size"
+				[status]="status"
+				[type]="type">
+			</ibm-progress-bar>`
+		,
+		props: {
+			label: text("Label", "Progress bar label"),
+			helperText: text("Helper text", "Optional helper text"),
+			size: select("Size", ["big", "small"], "big"),
+			status: select("Status", ["active", "finished", "error"], "active"),
+			type: select("Type", ["default", "inline", "indented"], "default")
+		}
+	}))
+	.add("Documentation", () => ({
+		template: `
+			<ibm-documentation src="documentation/classes/src_progress_bar.progressbar.html"></ibm-documentation>
+		`
+	}));


### PR DESCRIPTION
* Back ports progress bar component from CCA v5 (Next) to v4.
* Progress bar component is marked as experimental in Carbon react v7 (Carbon 10), but all tests from v5 pass & I do not suspect any major changes to be made to this component in v4.
