### PR TITLE
fix: Make column directive reactive for input props

### DIFF
--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -37,7 +37,7 @@ export class RowDirective {
 @Directive({
 	selector: "[ibmCol]"
 })
-export class ColumnDirective implements OnInit {
+export class ColumnDirective implements OnInit, OnChanges {
 	@Input() class = "";
 
 	@Input() columnNumbers = {};
@@ -54,8 +54,8 @@ export class ColumnDirective implements OnInit {
 	set(classes: string) {
 		this._columnClasses = classes.split(" ");
 	}
-
-	ngOnInit() {
+	
+	setUp() {
 		try {
 			const columnKeys = Object.keys(this.columnNumbers);
 			if (columnKeys.length <= 0) {
@@ -81,4 +81,12 @@ export class ColumnDirective implements OnInit {
 			this._columnClasses.push(this.class);
 		}
 	}
+
+	ngOnInit() {
+		this.setUp();
+	}
+	
+	ngOnChanges(changes: SimpleChanges): void {
+    	this.setUp();
+  	}
 }

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -81,12 +81,4 @@ export class ColumnDirective implements OnInit, OnChanges {
 			this._columnClasses = [...new Set([...this._columnClasses, ...this.class.split(" ")])];
 		}
 	}
-
-	ngOnInit() {
-		this.setUp();
-	}
-
-	ngOnChanges(changes: SimpleChanges): void {
-    	this.setUp();
-  	}
 }

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding, Input, OnInit } from "@angular/core";
+import { Directive, HostBinding, Input, OnInit, OnChanges, SimpleChanges } from "@angular/core";
 
 /**
  * [See demo](../../?path=/story/components-grid--basic)
@@ -54,7 +54,7 @@ export class ColumnDirective implements OnInit, OnChanges {
 	set(classes: string) {
 		this._columnClasses = classes.split(" ");
 	}
-	
+
 	setUp() {
 		try {
 			const columnKeys = Object.keys(this.columnNumbers);
@@ -85,7 +85,7 @@ export class ColumnDirective implements OnInit, OnChanges {
 	ngOnInit() {
 		this.setUp();
 	}
-	
+
 	ngOnChanges(changes: SimpleChanges): void {
     	this.setUp();
   	}

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -63,7 +63,7 @@ export class ColumnDirective implements OnChanges {
 	ngOnChanges() {
 		try {
 			// Reset classes so we don't apply classes for the same breakpoint multiple times
-			this.columnClasses = "";
+			this._columnClasses = "";
 			const columnKeys = Object.keys(this.columnNumbers);
 			if (columnKeys.length <= 0) {
 				this._columnClasses.push("bx--col");

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -37,7 +37,7 @@ export class RowDirective {
 @Directive({
 	selector: "[ibmCol]"
 })
-export class ColumnDirective implements OnInit, OnChanges {
+export class ColumnDirective implements OnChanges {
 	@Input() class = "";
 
 	@Input() columnNumbers = {};

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -56,14 +56,14 @@ export class ColumnDirective implements OnChanges {
 		return this._columnClasses.join(" ");
 	}
 
-	set(classes: string) {
+	set columnClasses(classes: string) {
 		this._columnClasses = classes.split(" ");
 	}
 
 	ngOnChanges() {
 		try {
 			// Reset classes so we don't apply classes for the same breakpoint multiple times
-			this._columnClasses = "";
+			this.columnClasses = "";
 			const columnKeys = Object.keys(this.columnNumbers);
 			if (columnKeys.length <= 0) {
 				this._columnClasses.push("bx--col");

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -2,8 +2,7 @@ import {
 	Directive,
 	HostBinding,
 	Input,
-	OnChanges,
-	SimpleChanges
+	OnChanges
 } from "@angular/core";
 
 /**

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -63,7 +63,7 @@ export class ColumnDirective implements OnChanges {
 	ngOnChanges() {
 		try {
 			// Reset classes so we don't apply classes for the same breakpoint multiple times
-			this.columnClasses = "";
+			this._columnClasses = [];
 			const columnKeys = Object.keys(this.columnNumbers);
 			if (columnKeys.length <= 0) {
 				this._columnClasses.push("bx--col");

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -78,7 +78,7 @@ export class ColumnDirective implements OnInit, OnChanges {
 		}
 
 		if (this.class) {
-			this._columnClasses.push(this.class);
+			this._columnClasses = [...new Set([...this._columnClasses, ...this.class.split(" ")])];
 		}
 	}
 

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -55,8 +55,10 @@ export class ColumnDirective implements OnChanges {
 		this._columnClasses = classes.split(" ");
 	}
 
-	setUp() {
+	ngOnChanges() {
 		try {
+			// Reset classes so we don't apply classes for the same breakpoint multiple times
+			this.columnClasses = "";
 			const columnKeys = Object.keys(this.columnNumbers);
 			if (columnKeys.length <= 0) {
 				this._columnClasses.push("bx--col");

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -1,4 +1,10 @@
-import { Directive, HostBinding, Input, OnInit, OnChanges, SimpleChanges } from "@angular/core";
+import { 
+	Directive,
+	HostBinding,
+	Input,
+	OnChanges,
+	SimpleChanges
+} from "@angular/core";
 
 /**
  * [See demo](../../?path=/story/components-grid--basic)


### PR DESCRIPTION
The current implementation lacks reactivity for the input props. Now, when a prop changes the directive will reflect these changes. This feature is required when the application needs to dynamically change the columns' disposition.

Closes carbon-design-system/carbon-components-angular#2385
