### PR TITLE
fix: Add 'data-invalid' attribute to apply appropriate styling to buttons when invalid

### DIFF
--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -66,6 +66,7 @@ export class NumberChange {
 					[disabled]="disabled"
 					[required]="required"
 					[attr.aria-label]="ariaLabel"
+					[attr.data-invalid]="invalid ? invalid : null"
 					(input)="onNumberInputChange($event)"/>
 				<svg
 					*ngIf="!skeleton && !warn && invalid"

--- a/src/number-input/number.stories.ts
+++ b/src/number-input/number.stories.ts
@@ -40,7 +40,7 @@ storiesOf("Components|Number", module).addDecorator(
 			max: number("max", 100),
 			step: number("step", 1),
 			precision: number("precision"),
-			invalid: boolean("Show form validation", false),
+			invalid: boolean("Show form validation (invalid)", false),
 			disabled: boolean("disabled", false)
 		}
 	}))


### PR DESCRIPTION
#### Changelog

**Changed**
* Added `data-invalid` attribute to Number Input to apply appropriate styling to buttons (+/-) for invalid state

Before:
![image](https://user-images.githubusercontent.com/38994122/210412276-267bfd76-8a2f-49da-ad48-e4078ae0c86a.png)


After:
![image](https://user-images.githubusercontent.com/38994122/210412210-47bd31bd-8ec9-44b6-9b2e-bfbf40bba616.png)
