### PR TITLE
fix: no disabled styling for disabled dropdown items

### DIFF
--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -67,10 +67,10 @@ import { ScrollCustomEvent } from "./scroll-custom-event.interface";
 				[attr.aria-selected]="item.selected"
 				[id]="getItemId(i)"
 				[attr.title]=" showTitles ? item.content : null"
+				[attr.disabled]="item.disabled"
 				[ngClass]="{
 					'bx--list-box__menu-item--active': item.selected,
-					'bx--list-box__menu-item--highlighted': highlightedItem === getItemId(i),
-					disabled: item.disabled
+					'bx--list-box__menu-item--highlighted': highlightedItem === getItemId(i)
 				}">
 				<div
 					#listItem
@@ -277,7 +277,6 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 		this.updateIndex();
 		this.setupFocusObservable();
 		setTimeout(() => {
-			if (this.getSelected() !== []) { return; }
 			this.doEmitSelect();
 		});
 	}


### PR DESCRIPTION
Signed-off-by: anemonetea <laz1anastasiya@gmail.com>

Closes carbon-design-system/carbon-components-angular#1409

There was an issue with the styling where disabled items wouldn't get any special styling even though clicking on them would not select the item as expected.

#### Issue screenshots
Dropdown before:
![Screenshot 2023-01-14 at 1 40 01 AM](https://user-images.githubusercontent.com/26636906/212462984-3451d92b-becc-4c64-9141-fae367575d80.png)

Combobox before:
![Screenshot 2023-01-14 at 3 25 00 AM](https://user-images.githubusercontent.com/26636906/212463359-b40902dd-879e-4af0-b702-2a5e9f4f1fd8.png)


Dropdown after:
![Screenshot 2023-01-14 at 3 14 59 AM](https://user-images.githubusercontent.com/26636906/212462990-5a985e5b-cec5-42f7-a5f8-ec1371e8826e.png)

Combobox after:
![Screenshot 2023-01-14 at 3 28 33 AM](https://user-images.githubusercontent.com/26636906/212463467-7e7574ff-0662-4bee-a0a6-98116dc204f4.png)


#### Changelog

**Changed**
Disabling a list-item within an `ibm-dropdown-list` component styles the item as disabled using existing Carbon SCSS.

Pre-existing SCSS: https://github.com/carbon-design-system/carbon/blob/056efd3400456342b6a6fb4f55dba26b5ff931c1/packages/styles/scss/components/list-box/_list-box.scss#L663-L691

Carbon SCSS uses an attribute selector on `bx--list-box__menu-item` (and not on its children) to apply styling to disabled list-items. So, I've added a `disabled` attribute to the element that has the `bx--list-box__menu-item` class on it.

**Removed**
Removed an empty list check that is redundant (due to `doEmitSelect()` having an equivalent) and incorrect because it's comparing array references by value. (my VSCode was highlighting this)
