### PR TITLE
fix(ColumnDirective): fixed missing class if no inputs provided

### DIFF
--- a/src/grid/grid.directive.spec.ts
+++ b/src/grid/grid.directive.spec.ts
@@ -80,4 +80,28 @@ describe("GridDirective", () => {
 			);
 		});
 	}));
+
+	it("should render a column without inputs", async(() => {
+		TestBed.overrideComponent(TestGridComponent, {
+			set: {
+				template:
+				`<div ibmCol></div>`
+			}
+		});
+
+		TestBed.compileComponents().then(() => {
+			const fixture = TestBed.createComponent(TestGridComponent);
+			const directiveEl = fixture.debugElement.query(
+				By.directive(ColumnDirective)
+			);
+			fixture.detectChanges();
+
+			expect(directiveEl).not.toBeNull();
+
+			const directiveInstance = directiveEl.injector.get(ColumnDirective);
+			expect(directiveInstance.columnClasses).toBe(
+				"bx--col"
+			);
+		});
+	}));
 });

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -49,7 +49,8 @@ export class ColumnDirective implements OnChanges {
 
 	@Input() offsets = {};
 
-	protected _columnClasses: string[] = [];
+	// initial value if no inputs are provided (if no inputs ngOnChanges won't be executed)
+	protected _columnClasses: string[] = ["bx--col"];
 
 	@HostBinding("class")
 	get columnClasses(): string {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2430

`ngOnChanges` was never called if no inputs were passed

#### Changelog

**Changed**

* added `bx--col` by default
* added UTs to cover this scenario

@zvonimirfras 