### PR TITLE
fix(Label): avoid Label component to override existing ids reuse them instead

### DIFF
--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -172,12 +172,19 @@ export class Label implements AfterContentInit, AfterViewInit {
 			// Prioritize setting id to `input` & `textarea` over div
 			const inputElement = this.wrapper.nativeElement.querySelector("input,textarea");
 			if (inputElement) {
+				// avoid overriding ids already set by the user reuse it instead
+				if (inputElement.id) {
+					this.labelInputID = inputElement.id;
+				}
 				inputElement.setAttribute("id", this.labelInputID);
 				return;
 			}
 
 			const divElement = this.wrapper.nativeElement.querySelector("div");
 			if (divElement) {
+				if (divElement.id) {
+					this.labelInputID = divElement.id;
+				}
 				divElement.setAttribute("id", this.labelInputID);
 			}
 		}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2447

in theory the label should only care about its direct children and not deeply seek for inputs/textareas, but at least it shouldn't override existing ids as this would cause issues somewhere else. This is why i added a check if the id already exists

#### Changelog

**Changed**

* the id is now applied only if it doesn't exists on inputs/textareas. No changes on how it applies it on divs