### PR TITLE
docs(readme): add discord link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
     <a href="https://bestpractices.coreinfrastructure.org/projects/5887">
       <img src="https://bestpractices.coreinfrastructure.org/projects/5887/badge">
     </a>
+    <a href="https://discord.gg/J7JEUEkTRX">
+      <img src="https://img.shields.io/discord/689212587170201628?color=5865F2" alt="Chat with us on Discord">
+    </a>
 	</p>
 </p>
 


### PR DESCRIPTION
Hey there! Just a small PR to add a link to discord in the readme. I'm opening PRs suggesting we do this for all the top repos in the carbon-design-system org.