### PR TITLE
feat: Readonly and inline ibm-label component for Input and TextArea

### DIFF
--- a/src/icon/icon.module.ts
+++ b/src/icon/icon.module.ts
@@ -35,6 +35,7 @@ import Delete16 from "@carbon/icons/es/delete/16";
 import Document16 from "@carbon/icons/es/document/16";
 import Document20 from "@carbon/icons/es/document/20";
 import Download16 from "@carbon/icons/es/download/16";
+import EditOff16 from "@carbon/icons/es/edit--off/16";
 import ErrorFilled16 from "@carbon/icons/es/error--filled/16";
 import ErrorFilled20 from "@carbon/icons/es/error--filled/20";
 import Fade16 from "@carbon/icons/es/fade/16";
@@ -113,6 +114,7 @@ export class IconModule {
 			Document16,
 			Document20,
 			Download16,
+			EditOff16,
 			ErrorFilled16,
 			ErrorFilled20,
 			Fade16,

--- a/src/input/input.directive.ts
+++ b/src/input/input.directive.ts
@@ -38,20 +38,4 @@ export class TextInput {
 	@HostBinding("class.bx--text-input--light") get isLightTheme() {
 		return this.theme === "light";
 	}
-	@HostBinding("attr.readonly") readonlyAttr: string = null;
-	@Input()
-	public set readonly(value: boolean) {
-		this._readonly = value;
-		// Set attribute based on input
-		if (this._readonly) {
-			this.readonlyAttr = "true";
-		} else {
-			this.readonlyAttr = null;
-		}
-	}
-	public get readonly(): boolean {
-		return this._readonly;
-	}
-	private _readonly: boolean;
-
 }

--- a/src/input/input.directive.ts
+++ b/src/input/input.directive.ts
@@ -38,4 +38,20 @@ export class TextInput {
 	@HostBinding("class.bx--text-input--light") get isLightTheme() {
 		return this.theme === "light";
 	}
+	@HostBinding("attr.readonly") readonlyAttr: string = null;
+	@Input()
+	public set readonly(value: boolean) {
+		this._readonly = value;
+		// Set attribute based on input
+		if (this._readonly) {
+			this.readonlyAttr = "true";
+		} else {
+			this.readonlyAttr = null;
+		}
+	}
+	public get readonly(): boolean {
+		return this._readonly;
+	}
+	private _readonly: boolean;
+
 }

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -159,6 +159,65 @@ storiesOf("Components|Input", module).addDecorator(
 			rows: number("rows", 4)
 		}
 	}))
+	.add("Label playground", () => ({
+		template: `
+		<ibm-label
+			[size]="size"
+			[disabled]="disabled"
+			[readonly]="readonly"
+			[inline]="inline"
+			[helperText]="helperText"
+			[invalid]="invalid"
+			[invalidText]="invalidText"
+			[warn]="warn"
+			[warnText]="warnText">
+			{{label}}
+			<input *ngIf="type === 'input'"
+				ibmText
+				[size]="size"
+				[invalid]="invalid"
+				[warn]="warn"
+				[disabled]="disabled"
+				[readonly]="readonly"
+				[theme]="theme"
+				[placeholder]="placeholder"
+				[autocomplete]="autocomplete">
+			<textarea *ngIf="type === 'textarea'"
+				ibmTextArea
+				[placeholder]="placeholder"
+				[invalid]="invalid"
+				[disabled]="disabled"
+				[theme]="theme"
+				[rows]="rows"
+				[cols]="cols"
+				aria-label="textarea"></textarea>
+			<div *ngIf="type === 'div'">
+				<p [ngClass]="{
+					'bx--text-input--sm': size === 'sm',
+					'bx--text-input--md': size === 'md',
+					'bx--text-input--xl': size === 'xl'
+				}">My custom component</p>
+			</div>
+		</ibm-label>
+	`,
+		props: {
+			theme: select("Theme", ["dark", "light"], "dark"),
+			size: select("Size", ["sm", "md", "xl"], "md"),
+			disabled: boolean("Disabled", false),
+			readonly: boolean("Read-only", false),
+			inline: boolean("Inline", false),
+			invalid: boolean("Show form validation", false),
+			invalidText: text("Form validation content", "Validation message here"),
+			warn: boolean("Show the warning state", false),
+			warnText: text("Text for the warning", "This is a warning"),
+			label: text("Label", "Text area label"),
+			helperText: text("Helper text", "Optional helper text."),
+			placeholder: text("Placeholder text", "Placeholder text"),
+			cols: number("cols", 50),
+			rows: number("rows", 4),
+			type: select("Content element type", ["input", "textarea", "div"], "input")
+		}
+	}))
 	.add("Skeleton", () => ({
 		template: `
 		<ibm-label skeleton="true">

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -130,7 +130,6 @@ storiesOf("Components|Input", module).addDecorator(
 		<ibm-label
 			[size]="size"
 			[disabled]="disabled"
-			[inline]="inline"
 			[helperText]="helperText"
 			[invalid]="invalid"
 			[invalidText]="invalidText">
@@ -149,7 +148,8 @@ storiesOf("Components|Input", module).addDecorator(
 		props: {
 			theme: select("Theme", ["dark", "light"], "dark"),
 			disabled: boolean("Disabled", false),
-			inline: boolean("Inline", false),
+			// readonly: boolean("Read-only", false),   // not supported for TextArea
+			// inline: boolean("Inline", false),   // not supported for TextArea
 			invalid: boolean("Show form validation", false),
 			invalidText: text("Form validation content", "Validation message here"),
 			label: text("Label", "Text area label"),

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -8,12 +8,13 @@ import {
 	number
 } from "@storybook/addon-knobs/angular";
 
-import { InputModule } from "../";
+import { InputModule } from ".";
+import { IconModule } from "../icon/icon.module";
 import { DocumentationModule } from "../documentation-component/documentation.module";
 
 storiesOf("Components|Input", module).addDecorator(
 	moduleMetadata({
-		imports: [InputModule, DocumentationModule]
+		imports: [InputModule, IconModule, DocumentationModule]
 	})
 )
 	.addDecorator(withKnobs)
@@ -30,7 +31,10 @@ storiesOf("Components|Input", module).addDecorator(
 		</a>
 		<br><br>
 		<ibm-label
+			[size]="size"
 			[disabled]="disabled"
+			[readonly]="readonly"
+			[inline]="inline"
 			[helperText]="helperText"
 			[invalid]="invalid"
 			[invalidText]="invalidText"
@@ -43,6 +47,7 @@ storiesOf("Components|Input", module).addDecorator(
 				[invalid]="invalid"
 				[warn]="warn"
 				[disabled]="disabled"
+				[readonly]="readonly"
 				[theme]="theme"
 				[placeholder]="placeholder"
 				[autocomplete]="autocomplete">
@@ -52,6 +57,8 @@ storiesOf("Components|Input", module).addDecorator(
 			theme: select("Theme", ["dark", "light"], "dark"),
 			size: select("Size", ["sm", "md", "xl"], "md"),
 			disabled: boolean("Disabled", false),
+			readonly: boolean("Read-only", false),
+			inline: boolean("Inline", false),
 			invalid: boolean("Show form validation", false),
 			invalidText: text("Form validation content", "Validation message here"),
 			warn: boolean("Show the warning state", false),
@@ -62,10 +69,68 @@ storiesOf("Components|Input", module).addDecorator(
 			autocomplete: text("autocomplete", "on")
 		}
 	}))
+	.add("Label with template", () => ({
+		template: `
+		<ng-template #helperTextTemplate let-type="type">
+			<div style="display: flex; align-items: center">
+				<svg ibmIcon="bee" size="16" class="bx--btn__icon" fill="#0043ce"></svg>
+				<span style="margin-left: 0.25rem;">My helper text</span>
+			</div>
+		</ng-template>
+		<ng-template #invalidTextTemplate>
+			<div style="display: flex; align-items: center">
+				<svg ibmIcon="bee" size="16" class="bx--btn__icon" fill="#da1e28"></svg>
+				<span style="margin-left: 0.25rem;">My invalid text</span>
+			</div>
+		</ng-template>
+		<ng-template #warningTextTemplate>
+			<div style="display: flex; align-items: center">
+				<svg ibmIcon="bee" size="16" class="bx--btn__icon" fill="#f1c21b"></svg>
+				<span style="margin-left: 0.25rem;">My warning text</span>
+			</div>
+		</ng-template>
+		<ibm-label
+			[size]="size"
+			[disabled]="disabled"
+			[readonly]="readonly"
+			[inline]="inline"
+			[helperText]="helperTextTemplate"
+			[invalid]="invalid"
+			[invalidText]="invalidTextTemplate"
+			[warn]="warn"
+			[warnText]="warningTextTemplate">
+			{{label}}
+			<input
+				ibmText
+				[size]="size"
+				[invalid]="invalid"
+				[warn]="warn"
+				[disabled]="disabled"
+				[readonly]="readonly"
+				[theme]="theme"
+				[placeholder]="placeholder"
+				[autocomplete]="autocomplete">
+		</ibm-label>
+	`,
+		props: {
+			theme: select("Theme", ["dark", "light"], "dark"),
+			size: select("Size", ["sm", "md", "xl"], "md"),
+			disabled: boolean("Disabled", false),
+			readonly: boolean("Read-only", false),
+			inline: boolean("Inline", false),
+			invalid: boolean("Show form validation", false),
+			warn: boolean("Show the warning state", false),
+			label: text("Label", "Text Input label"),
+			placeholder: text("Placeholder text", "Placeholder text"),
+			autocomplete: text("autocomplete", "on")
+		}
+	}))
 	.add("TextArea", () => ({
 		template: `
 		<ibm-label
+			[size]="size"
 			[disabled]="disabled"
+			[inline]="inline"
 			[helperText]="helperText"
 			[invalid]="invalid"
 			[invalidText]="invalidText">
@@ -84,6 +149,7 @@ storiesOf("Components|Input", module).addDecorator(
 		props: {
 			theme: select("Theme", ["dark", "light"], "dark"),
 			disabled: boolean("Disabled", false),
+			inline: boolean("Inline", false),
 			invalid: boolean("Show form validation", false),
 			invalidText: text("Form validation content", "Validation message here"),
 			label: text("Label", "Text area label"),

--- a/src/input/label.component.spec.ts
+++ b/src/input/label.component.spec.ts
@@ -2,39 +2,55 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
 import { Label } from "./label.component";
+import { Component, ViewChild } from "@angular/core";
+import { TextInput } from "./input.directive";
+
+@Component({
+	template: `
+		<ibm-label>
+			<input ibmText value="test">
+		</ibm-label>
+	`
+})
+class TestLabelHostComponent {
+	@ViewChild(Label) labelChild: Label;
+}
 
 describe("Label", () => {
+	let hostComponent: TestLabelHostComponent;
 	let component: Label;
-	let fixture: ComponentFixture<Label>;
+	let hostFixture: ComponentFixture<TestLabelHostComponent>;
 
 	const outerWrapperClass = ".bx--text-input__field-outer-wrapper";
 	const inputWrapperClass = ".bx--text-input__field-wrapper";
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			declarations: [Label],
+			declarations: [Label, TestLabelHostComponent, TextInput],
 			imports: [],
 			providers: []
 		});
 
-		fixture = TestBed.createComponent(Label);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+		hostFixture = TestBed.createComponent(TestLabelHostComponent);
+		hostComponent = hostFixture.componentInstance;
+		hostFixture.detectChanges();
+		component = hostComponent.labelChild;
 	});
 
 	it("should work", () => {
 		expect(component instanceof Label).toBe(true);
-		expect(fixture.debugElement.classes["bx--form-item"]).toBeTruthy();
-		expect(fixture.debugElement.classes["bx--text-input-wrapper"]).toBeTruthy();
+		let labelEl = hostFixture.debugElement.query(By.css("ibm-label"));
+		expect(labelEl.classes["bx--form-item"]).toBeTruthy();
+		expect(labelEl.classes["bx--text-input-wrapper"]).toBeTruthy();
 	});
 
 	it("should set helper text", () => {
 		const expectedHelperText = "My helper text";
 
 		component.helperText = expectedHelperText;
-		fixture.detectChanges();
+		hostFixture.detectChanges();
 		const helperTextClass = ".bx--form__helper-text";
-		let helperTextContainerEls = fixture.debugElement.queryAll(
+		let helperTextContainerEls = hostFixture.debugElement.queryAll(
 			By.css(outerWrapperClass + ">" + helperTextClass)
 		);
 		expect(helperTextContainerEls).toBeDefined();
@@ -46,9 +62,9 @@ describe("Label", () => {
 
 	it("should set icon to warning for warning state", () => {
 		component.warn = true;
-		fixture.detectChanges();
+		hostFixture.detectChanges();
 		const svgSelector = "svg.bx--text-input__invalid-icon.bx--text-input__invalid-icon--warning";
-		let svgEls = fixture.debugElement.queryAll(
+		let svgEls = hostFixture.debugElement.queryAll(
 			By.css(outerWrapperClass + ">" + inputWrapperClass + ">" + svgSelector)
 		);
 		expect(svgEls).toBeDefined();
@@ -60,9 +76,9 @@ describe("Label", () => {
 
 		component.warn = true;
 		component.warnText = expectedWaringText;
-		fixture.detectChanges();
+		hostFixture.detectChanges();
 		const requiredTextClass = ".bx--form-requirement";
-		let helperTextContainerEls = fixture.debugElement.queryAll(
+		let helperTextContainerEls = hostFixture.debugElement.queryAll(
 			By.css(outerWrapperClass + ">" + requiredTextClass)
 		);
 		expect(helperTextContainerEls).toBeDefined();
@@ -74,9 +90,9 @@ describe("Label", () => {
 
 	it("should set icon to error in invalid state", () => {
 		component.invalid = true;
-		fixture.detectChanges();
+		hostFixture.detectChanges();
 		const svgSelector = "svg.bx--text-input__invalid-icon";
-		let svgEls = fixture.debugElement.queryAll(
+		let svgEls = hostFixture.debugElement.queryAll(
 			By.css(outerWrapperClass + ">" + inputWrapperClass + ">" + svgSelector)
 		);
 		expect(svgEls).toBeDefined();
@@ -88,8 +104,8 @@ describe("Label", () => {
 
 		component.invalid = true;
 		component.invalidText = expectedInvalidText;
-		fixture.detectChanges();
-		let helperTextContainerEls = fixture.debugElement.queryAll(
+		hostFixture.detectChanges();
+		let helperTextContainerEls = hostFixture.debugElement.queryAll(
 			By.css(".bx--text-input__field-outer-wrapper > .bx--form-requirement")
 		);
 		expect(helperTextContainerEls).toBeDefined();
@@ -101,9 +117,9 @@ describe("Label", () => {
 
 	it("should set icon to readonly in readonly state", () => {
 		component.readonly = true;
-		fixture.detectChanges();
+		hostFixture.detectChanges();
 		const svgSelector = "svg.bx--text-input__readonly-icon";
-		let svgEls = fixture.debugElement.queryAll(
+		let svgEls = hostFixture.debugElement.queryAll(
 			By.css(outerWrapperClass + ">" + inputWrapperClass + ">" + svgSelector)
 		);
 		expect(svgEls).toBeDefined();
@@ -113,14 +129,14 @@ describe("Label", () => {
 	it("should set inline classes in inline state", () => {
 		component.inline = true;
 		component.helperText = "test helpful text";
-		fixture.detectChanges();
 
-		let labelEls = fixture.debugElement.queryAll(
+		hostFixture.detectChanges();
+		let labelEls = hostFixture.debugElement.queryAll(
 			By.css(".bx--text-input__label-helper-wrapper > label")
 		);
 		expect(labelEls.length).toBe(1);
 
-		let helperTextEls = fixture.debugElement.queryAll(
+		let helperTextEls = hostFixture.debugElement.queryAll(
 			By.css(".bx--form__helper-text")
 		);
 		expect(helperTextEls.length).toBe(1);
@@ -131,7 +147,7 @@ describe("Label", () => {
 		let helperTextElInlineClass = helperTextEls[0].classes["bx--form__helper-text--inline"];
 		expect(helperTextElInlineClass).toBeTruthy();
 
-		let inputWrapperEls = fixture.debugElement.queryAll(
+		let inputWrapperEls = hostFixture.debugElement.queryAll(
 			By.css(".bx--text-input__field-outer-wrapper.bx--text-input__field-outer-wrapper--inline")
 		);
 		expect(inputWrapperEls.length).toBe(1);

--- a/src/input/label.component.spec.ts
+++ b/src/input/label.component.spec.ts
@@ -1,14 +1,14 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { DebugElement } from "@angular/core";
 
 import { Label } from "./label.component";
 
 describe("Label", () => {
 	let component: Label;
 	let fixture: ComponentFixture<Label>;
-	let de: DebugElement;
-	let el: HTMLElement;
+
+	const outerWrapperClass = ".bx--text-input__field-outer-wrapper";
+	const inputWrapperClass = ".bx--text-input__field-wrapper";
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
@@ -19,30 +19,121 @@ describe("Label", () => {
 
 		fixture = TestBed.createComponent(Label);
 		component = fixture.componentInstance;
-		de = fixture.debugElement.query(By.css(".label"));
-		el = de.nativeElement;
 		fixture.detectChanges();
 	});
 
-	xit("should work", () => {
+	it("should work", () => {
 		expect(component instanceof Label).toBe(true);
+		expect(fixture.debugElement.classes["bx--form-item"]).toBeTruthy();
+		expect(fixture.debugElement.classes["bx--text-input-wrapper"]).toBeTruthy();
 	});
 
-	xit("should set icon to success", () => {
-		component.labelState = "success";
+	it("should set helper text", () => {
+		const expectedHelperText = "My helper text";
+
+		component.helperText = expectedHelperText;
 		fixture.detectChanges();
-		expect(el.querySelector(".label-icon-success")).toBeTruthy();
+		const helperTextClass = ".bx--form__helper-text";
+		let helperTextContainerEls = fixture.debugElement.queryAll(
+			By.css(outerWrapperClass + ">" + helperTextClass)
+		);
+		expect(helperTextContainerEls).toBeDefined();
+		expect(helperTextContainerEls.length).toBe(1);
+
+		let helperTextContainerEl = helperTextContainerEls[0];
+		expect(helperTextContainerEl.nativeElement.textContent).toBe(expectedHelperText);
 	});
 
-	xit("should set icon to warning", () => {
-		component.labelState = "warning";
+	it("should set icon to warning for warning state", () => {
+		component.warn = true;
 		fixture.detectChanges();
-		expect(el.querySelector(".label-icon-warning")).toBeTruthy();
+		const svgSelector = "svg.bx--text-input__invalid-icon.bx--text-input__invalid-icon--warning";
+		let svgEls = fixture.debugElement.queryAll(
+			By.css(outerWrapperClass + ">" + inputWrapperClass + ">" + svgSelector)
+		);
+		expect(svgEls).toBeDefined();
+		expect(svgEls.length).toBe(1);
 	});
 
-	xit("should set icon to error", () => {
-		component.labelState = "error";
+	it("should set warning text in warn state", () => {
+		const expectedWaringText = "My warning text";
+
+		component.warn = true;
+		component.warnText = expectedWaringText;
 		fixture.detectChanges();
-		expect(el.querySelector(".label-icon-error")).toBeTruthy();
+		const requiredTextClass = ".bx--form-requirement";
+		let helperTextContainerEls = fixture.debugElement.queryAll(
+			By.css(outerWrapperClass + ">" + requiredTextClass)
+		);
+		expect(helperTextContainerEls).toBeDefined();
+		expect(helperTextContainerEls.length).toBe(1);
+
+		let helperTextContainerEl = helperTextContainerEls[0];
+		expect(helperTextContainerEl.nativeElement.textContent).toBe(expectedWaringText);
+	});
+
+	it("should set icon to error in invalid state", () => {
+		component.invalid = true;
+		fixture.detectChanges();
+		const svgSelector = "svg.bx--text-input__invalid-icon";
+		let svgEls = fixture.debugElement.queryAll(
+			By.css(outerWrapperClass + ">" + inputWrapperClass + ">" + svgSelector)
+		);
+		expect(svgEls).toBeDefined();
+		expect(svgEls.length).toBe(1);
+	});
+
+	it("should set error text in invalid state", () => {
+		const expectedInvalidText = "My error text";
+
+		component.invalid = true;
+		component.invalidText = expectedInvalidText;
+		fixture.detectChanges();
+		let helperTextContainerEls = fixture.debugElement.queryAll(
+			By.css(".bx--text-input__field-outer-wrapper > .bx--form-requirement")
+		);
+		expect(helperTextContainerEls).toBeDefined();
+		expect(helperTextContainerEls.length).toBe(1);
+
+		let helperTextContainerEl = helperTextContainerEls[0];
+		expect(helperTextContainerEl.nativeElement.textContent).toBe(expectedInvalidText);
+	});
+
+	it("should set icon to readonly in readonly state", () => {
+		component.readonly = true;
+		fixture.detectChanges();
+		const svgSelector = "svg.bx--text-input__readonly-icon";
+		let svgEls = fixture.debugElement.queryAll(
+			By.css(outerWrapperClass + ">" + inputWrapperClass + ">" + svgSelector)
+		);
+		expect(svgEls).toBeDefined();
+		expect(svgEls.length).toBe(1);
+	});
+
+	it("should set inline classes in inline state", () => {
+		component.inline = true;
+		component.helperText = "test helpful text";
+		fixture.detectChanges();
+
+		let labelEls = fixture.debugElement.queryAll(
+			By.css(".bx--text-input__label-helper-wrapper > label")
+		);
+		expect(labelEls.length).toBe(1);
+
+		let helperTextEls = fixture.debugElement.queryAll(
+			By.css(".bx--form__helper-text")
+		);
+		expect(helperTextEls.length).toBe(1);
+
+		let labelElInlineClass = labelEls[0].classes["bx--label--inline"];
+		expect(labelElInlineClass).toBeTruthy();
+
+		let helperTextElInlineClass = helperTextEls[0].classes["bx--form__helper-text--inline"];
+		expect(helperTextElInlineClass).toBeTruthy();
+
+		let inputWrapperEls = fixture.debugElement.queryAll(
+			By.css(".bx--text-input__field-outer-wrapper.bx--text-input__field-outer-wrapper--inline")
+		);
+		expect(inputWrapperEls.length).toBe(1);
 	});
 });

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -51,12 +51,12 @@ import { TextInput } from "./input.directive";
 			<div
 				[class]="wrapperClass"
 				[ngClass]="{
-					'bx--text-input__field-wrapper--warning': warn
+					'bx--text-input__field-wrapper--warning': isWarning
 				}"
 				[attr.data-invalid]="(invalid ? true : null)"
 				#wrapper>
 				<svg
-					*ngIf="!warn && invalid && !isReadonly"
+					*ngIf="!isWarning && invalid && !isReadonly"
 					ibmIcon="warning--filled"
 					size="16"
 					[ngClass]="{
@@ -65,7 +65,7 @@ import { TextInput } from "./input.directive";
 					}">
 				</svg>
 				<svg
-					*ngIf="!invalid && warn && !isReadonly"
+					*ngIf="!invalid && isWarning && !isReadonly"
 					ibmIcon="warning--alt--filled"
 					size="16"
 					class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
@@ -84,7 +84,7 @@ import { TextInput } from "./input.directive";
 		</div>
 
 		<ng-template #helperTextTemplate>
-			<div *ngIf="!skeleton && helperText && ((!invalid && !warn) || isInline)"
+			<div *ngIf="!skeleton && helperText && ((!invalid && !isWarning) || isInline)"
 				class="bx--form__helper-text"
 				[ngClass]="{
 					'bx--form__helper-text--disabled': disabled,
@@ -93,11 +93,11 @@ import { TextInput } from "./input.directive";
 				<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 				<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 			</div>
-			<div *ngIf="!isInline && !warn && invalid" class="bx--form-requirement">
+			<div *ngIf="!isInline && !isWarning && invalid" class="bx--form-requirement">
 				<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
 				<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
 			</div>
-			<div *ngIf="!isInline && !invalid && warn" class="bx--form-requirement">
+			<div *ngIf="!isInline && !invalid && isWarning" class="bx--form-requirement">
 				<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
 				<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
 			</div>
@@ -175,7 +175,15 @@ export class Label implements AfterContentChecked, AfterViewInit {
 	/**
 	  * Set to `true` to show a warning (contents set by warningText)
 	  */
-	@Input() warn = false;
+	@Input() set warn(value: boolean) {
+		this._warn = value;
+	}
+	get warn(): boolean {
+		return this._warn;
+	}
+	get isWarning(): boolean {
+		return this._warn && this.textArea == undefined;
+	}
 	/**
 	 * Sets the warning text
 	 */
@@ -201,6 +209,7 @@ export class Label implements AfterContentChecked, AfterViewInit {
 
 	protected _readonly = false;
 	protected _inline = false;
+	protected _warn = false;
 
 	/**
 	 * Creates an instance of Label.

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -7,11 +7,12 @@ import {
 	TemplateRef,
 	ViewChild,
 	ContentChild,
-	AfterContentInit,
-	ChangeDetectorRef
+	ChangeDetectorRef,
+	AfterContentChecked
 } from "@angular/core";
 
 import { TextArea } from "./text-area.directive";
+import { TextInput } from "./input.directive";
 
 /**
  * [See demo](../../?path=/story/components-input--label)
@@ -103,7 +104,7 @@ import { TextArea } from "./text-area.directive";
 		<ng-template>
 	`
 })
-export class Label implements AfterContentInit, AfterViewInit {
+export class Label implements AfterContentChecked, AfterViewInit {
 	/**
 	 * Used to build the id of the input item associated with the `Label`.
 	 */
@@ -141,7 +142,7 @@ export class Label implements AfterContentInit, AfterViewInit {
 		return this._readonly;
 	}
 	@HostBinding("class.bx--text-input-wrapper--readonly") get isReadonly(): boolean {
-		return this._readonly && !this.textArea;
+		return this._readonly && this.textInput != undefined;
 	}
 	/**
 	 * Set to `true` for an isInline style label.
@@ -153,7 +154,7 @@ export class Label implements AfterContentInit, AfterViewInit {
 		return this._inline;
 	}
 	@HostBinding("class.bx--text-input-wrapper--inline") get isInline(): boolean {
-		return this._inline && !this.textArea;
+		return this._inline && this.textInput != undefined;
 	}
 	/**
 	 * Set to `true` for a loading label.
@@ -190,9 +191,12 @@ export class Label implements AfterContentInit, AfterViewInit {
 	// @ts-ignore
 	@ContentChild(TextArea, { static: false }) textArea: TextArea;
 
+	// @ts-ignore
+	@ContentChild(TextInput, { static: false }) textInput: TextInput;
+
 	@HostBinding("class.bx--form-item") labelClass = true;
 	@HostBinding("class.bx--text-input-wrapper") get inputWrapperClass(): boolean {
-		return !this.textArea;
+		return this.textInput != undefined;
 	}
 
 	protected _readonly = false;
@@ -208,9 +212,11 @@ export class Label implements AfterContentInit, AfterViewInit {
 	/**
 	 * Update wrapper class if a textarea is hosted.
 	 */
-	ngAfterContentInit() {
-		if (this.textArea) {
+	ngAfterContentChecked() {
+		if (this.textArea != undefined && this.wrapperClass !== "bx--text-area__wrapper") {
 			this.wrapperClass = "bx--text-area__wrapper";
+		} else if (this.textInput != undefined && this.wrapperClass !== "bx--text-input__field-wrapper") {
+			this.wrapperClass = "bx--text-input__field-wrapper";
 		}
 	}
 

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -16,77 +16,91 @@ import { TextArea } from "./text-area.directive";
 /**
  * [See demo](../../?path=/story/components-input--label)
  *
- * ```html
- * <ibm-label labelState="success">
- * 	<label label>Field with success</label>
- * 	<input type="text" class="input-field">
- * </ibm-label>
- *
- * <ibm-label labelState="warning">
- * 	<label label>Field with warning</label>
- * 	<input type="text" class="input-field">
- * </ibm-label>
- *
- * <ibm-label labelState="error">
- * 	<label label>Field with error</label>
- * 	<input type="text" class="input-field">
- * </ibm-label>
- * ```
- *
  * <example-url>../../iframe.html?id=components-input--label</example-url>
  */
 @Component({
 	selector: "ibm-label",
 	template: `
-		<label
-			[for]="labelInputID"
-			[attr.aria-label]="ariaLabel"
-			class="bx--label"
+		<div
 			[ngClass]="{
-				'bx--label--disabled': disabled,
-				'bx--skeleton': skeleton
+				'bx--text-input__label-helper-wrapper': inline
 			}">
-			<ng-content></ng-content>
-		</label>
-		<div
-			[class]="wrapperClass"
-			[ngClass]="{
-				'bx--text-input__field-wrapper--warning': warn
-			}"
-			[attr.data-invalid]="(invalid ? true : null)"
-			#wrapper>
-			<svg
-				*ngIf="!warn && invalid"
-				ibmIcon="warning--filled"
-				size="16"
+			<label
+				[for]="labelInputID"
+				[attr.aria-label]="ariaLabel"
+				class="bx--label"
 				[ngClass]="{
-					'bx--text-input__invalid-icon': !textArea,
-					'bx--text-area__invalid-icon': textArea
+					'bx--label--disabled': disabled,
+					'bx--skeleton': skeleton,
+					'bx--label--inline': inline,
+					'bx--label--inline--sm': (inline && size === 'sm'),
+					'bx--label--inline--md': (inline && size === 'md'),
+					'bx--label--inline--xl': (inline && size === 'xl')
 				}">
-			</svg>
-			<svg
-				*ngIf="!invalid && warn"
-				ibmIcon="warning--alt--filled"
-				size="16"
-				class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
-			</svg>
-			<ng-content select="input,textarea,div"></ng-content>
+				<ng-content></ng-content>
+			</label>
+			<ng-template *ngIf="inline"
+				[ngTemplateOutlet]="helperTextTemplate">
+			</ng-template>
 		</div>
-		<div
-			*ngIf="!skeleton && helperText && !invalid && !warn"
-			class="bx--form__helper-text"
-			[ngClass]="{'bx--form__helper-text--disabled': disabled}">
-			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
-			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
+		<div class="bx--text-input__field-outer-wrapper"
+			[ngClass]="{
+			'bx--text-input__field-outer-wrapper--inline': inline
+			}">
+			<div
+				[class]="wrapperClass"
+				[ngClass]="{
+					'bx--text-input__field-wrapper--warning': warn
+				}"
+				[attr.data-invalid]="(invalid ? true : null)"
+				#wrapper>
+				<svg
+					*ngIf="!warn && invalid && !hasReadonlyStyle"
+					ibmIcon="warning--filled"
+					size="16"
+					[ngClass]="{
+						'bx--text-input__invalid-icon': !textArea,
+						'bx--text-area__invalid-icon': textArea
+					}">
+				</svg>
+				<svg
+					*ngIf="!invalid && warn && !hasReadonlyStyle"
+					ibmIcon="warning--alt--filled"
+					size="16"
+					class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
+				</svg>
+				<svg
+					*ngIf="hasReadonlyStyle"
+					ibmIcon="edit--off"
+					size="16"
+					class="bx--text-input__readonly-icon">
+				</svg>
+				<ng-content select="input,textarea,div"></ng-content>
+			</div>
+			<ng-container *ngIf="!inline"
+				[ngTemplateOutlet]="helperTextTemplate">
+			</ng-container>
 		</div>
-		<div *ngIf="!warn && invalid" class="bx--form-requirement">
-			<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
-			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
-		</div>
-		<div *ngIf="!invalid && warn" class="bx--form-requirement">
-			<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
-			<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
-		</div>
+
+		<ng-template #helperTextTemplate>
+			<div *ngIf="!skeleton && helperText && ((!invalid && !warn) || inline)"
+				class="bx--form__helper-text"
+				[ngClass]="{
+					'bx--form__helper-text--disabled': disabled,
+					'bx--form__helper-text--inline': inline
+				}">
+				<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+				<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
+			</div>
+			<div *ngIf="!inline && !warn && invalid" class="bx--form-requirement">
+				<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
+				<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+			</div>
+			<div *ngIf="!inline && !invalid && warn" class="bx--form-requirement">
+				<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+				<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
+			</div>
+		<ng-template>
 	`
 })
 export class Label implements AfterContentInit, AfterViewInit {
@@ -106,12 +120,25 @@ export class Label implements AfterContentInit, AfterViewInit {
 
 	/**
 	 * State of the `Label` will determine the styles applied.
+	 * @deprecated
 	 */
 	@Input() labelState: "success" | "warning" | "error" | "" = "";
+	/**
+	 * Set the label size similar to the input size.
+	 */
+	@Input() size: "sm" | "md" | "xl" = "md";
 	/**
 	 * Set to `true` for a disabled label.
 	 */
 	@Input() disabled = false;
+	/**
+	 * Set to `true` for a read-only label.
+	 */
+	@Input() @HostBinding("class.bx--text-input-wrapper--readonly") readonly = false;
+	/**
+	 * Set to `true` for an inline style label.
+	 */
+	@Input() @HostBinding("class.bx--text-input-wrapper--inline") inline = false;
 	/**
 	 * Set to `true` for a loading label.
 	 */
@@ -148,6 +175,11 @@ export class Label implements AfterContentInit, AfterViewInit {
 	@ContentChild(TextArea, { static: false }) textArea: TextArea;
 
 	@HostBinding("class.bx--form-item") labelClass = true;
+	@HostBinding("class.bx--text-input-wrapper") inputWrapperClass = true;
+
+	public get hasReadonlyStyle(): boolean {
+		return this.readonly && !this.textArea;
+	}
 
 	/**
 	 * Creates an instance of Label.
@@ -155,6 +187,7 @@ export class Label implements AfterContentInit, AfterViewInit {
 	constructor(protected changeDetectorRef: ChangeDetectorRef) {
 		Label.labelCounter++;
 	}
+
 
 	/**
 	 * Update wrapper class if a textarea is hosted.


### PR DESCRIPTION
Closes:
carbon-design-system/carbon-components-angular#2291

Changing the `ibm-label` component to add inputs for `inline` and `readonly` options to match what is being done in React:
- React: https://github.com/carbon-design-system/carbon/blob/v10/packages/react/src/components/TextInput/TextInput.js
- Scss: https://github.com/carbon-design-system/carbon/blob/v10/packages/styles/scss/components/text-input/_text-input.scss

#### Changelog

**New**

* Inline styling of `ibm-label` controlled by `[inline]` input
* Readonly styling of `ibm-label` controlled by `[readonly]` input
* Readonly behaviour for `input` and `textarea` elements added to `ibmText` and `ibmTextArea` directives using `[readonly]` input
* StoryBook example of input components that use templates as `ibm-label` helper text inputs

**Changed**

* Fixed unit tests for input component

**Removed**
N/A