### PR TITLE
fix: Correct tab header type to 'line' & 'contained'

### DIFF
--- a/src/tabs/tabs.component.ts
+++ b/src/tabs/tabs.component.ts
@@ -98,7 +98,7 @@ export class Tabs implements AfterContentInit, OnChanges {
 	/**
 	 * Sets the type of the `TabHeader`s
 	 */
-	@Input() type: "default" | "container" = "default";
+	@Input() type: "line" | "contained" = "line";
 	/**
 	 * Sets the theme of `TabHeader`s
 	 */


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2467

In CCA v5, we updated the tab types to 'line' & 'contained' to match tab type names in carbon v11.
