### PR TITLE
fix: dropdown list keyboard scroll not working

### DIFF
--- a/src/dropdown/dropdown.stories.ts
+++ b/src/dropdown/dropdown.stories.ts
@@ -63,7 +63,13 @@ const getProps = (overrides = {}) => Object.assign({}, {
 		{ content: "one" },
 		{ content: "two", selected: true },
 		{ content: "three", disabled: true },
-		{ content: "four", disabled: false }
+		{ content: "four", disabled: false },
+		{ content: "five", disabled: false },
+		{ content: "six", disabled: false },
+		{ content: "seven", disabled: false },
+		{ content: "eight", disabled: false },
+		{ content: "nine", disabled: false },
+		{ content: "ten", disabled: false }
 	]),
 	selected: action("Selected fired for dropdown"),
 	onClose: action("Dropdown closed"),

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -539,13 +539,13 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 			event.preventDefault();
 			if (event.key === "ArrowDown" || event.key === "Down") {
 				if (this.hasNextElement()) {
-					this.getNextElement();
+					this.getNextElement().scrollIntoView({behavior: 'smooth',block: 'end'});
 				} else {
 					this.blurIntent.emit("bottom");
 				}
 			} else if (event.key === "ArrowUp" || event.key === "Up") {
 				if (this.hasPrevElement()) {
-					this.getPrevElement();
+					this.getPrevElement().scrollIntoView({behavior: 'smooth'});
 				} else {
 					this.blurIntent.emit("top");
 				}

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -539,13 +539,13 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 			event.preventDefault();
 			if (event.key === "ArrowDown" || event.key === "Down") {
 				if (this.hasNextElement()) {
-					this.getNextElement().scrollIntoView({behavior: "smooth", block: "end"});
+					this.getNextElement().scrollIntoView({block: "end"});
 				} else {
 					this.blurIntent.emit("bottom");
 				}
 			} else if (event.key === "ArrowUp" || event.key === "Up") {
 				if (this.hasPrevElement()) {
-					this.getPrevElement().scrollIntoView({behavior: "smooth"});
+					this.getPrevElement().scrollIntoView();
 				} else {
 					this.blurIntent.emit("top");
 				}

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -539,13 +539,13 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 			event.preventDefault();
 			if (event.key === "ArrowDown" || event.key === "Down") {
 				if (this.hasNextElement()) {
-					this.getNextElement().scrollIntoView({behavior: 'smooth',block: 'end'});
+					this.getNextElement().scrollIntoView({behavior: "smooth", block: "end"});
 				} else {
 					this.blurIntent.emit("bottom");
 				}
 			} else if (event.key === "ArrowUp" || event.key === "Up") {
 				if (this.hasPrevElement()) {
-					this.getPrevElement().scrollIntoView({behavior: 'smooth'});
+					this.getPrevElement().scrollIntoView({behavior: "smooth"});
 				} else {
 					this.blurIntent.emit("top");
 				}


### PR DESCRIPTION
Closes: [#2389](https://github.com/carbon-design-system/carbon-components-angular/issues/2389)

Dropdown list was scrollable using mouse but with keyboard list was not scrolling. checked keyboard navigation of dropdown list `navigateList` and found out that upon navigation from arrow keys html elements were missing with scroll behavior. On adding `scrollIntoView` the list scroll is working as expected with keyboard.
Took dropdown list scroll behavior reference from - [carbon design react](https://react.carbondesignsystem.com/?path=/story/components-dropdown--default)

**Before**
![issue](https://user-images.githubusercontent.com/36883992/222426907-a3166f41-14b0-447d-a521-477a83923762.gif)

**After**
![issue](https://user-images.githubusercontent.com/36883992/222426556-22faab74-31ff-46cf-ad77-78efaa502e99.gif)

