### PR TITLE
fix: Update toolbar size class 

### DIFF
--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -48,7 +48,7 @@ import { TableRowSize } from "../table.types";
 	template: `
 	<section
 		class="cds--table-toolbar"
-		[ngClass]="{'cds--table-toolbar--small' : size === 'sm'}">
+		[ngClass]="{'cds--table-toolbar--sm' : size === 'sm'}">
 		<div
 			*ngIf="model"
 			class="cds--batch-actions"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2484

Updates:
* Corrects the size class in toolbar size.

![image](https://user-images.githubusercontent.com/38994122/225954241-7bcf5585-52f5-4267-863b-4a093753f0f2.png)
