### PR TITLE
fix: Prevent padding on setTimeout on first change

### DIFF
--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -155,7 +155,7 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 		if (changes.isOpen) {
 			if (changes.isOpen.currentValue) {
 				this.open();
-			} else {
+			} else if (!changes.isOpen.firstChange) {
 				this.close({
 					reason: CloseReasons.programmatic
 				});


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2472

This change improves performance in tables where there are `many` (n) rows with overflow menus. Prior to this change, the setTimeout function in `close` function was being called for each overflow menu on initial load which added `n` number of entries to the list (queue) of active timeouts for handling. Since they all had the same amount of `delay`, the next setTimeout  handler in queue had to wait until the invocation of the handler of the current has completed. So for example with 300 rows, we the last setTimeout in queue would show that it took 20 - 25 seconds for the handler to be called. For more information, view the standard for setTimeout [implementation](https://www.w3.org/TR/2011/WD-html5-20110525/timers.html).

#### Changelog

**Changed**
* No longer calling close function on first change since it will be closed by default unless user programmatically opens it on initial load.