### PR TITLE
fix(tabs): fix tab headers resize/scroll issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10112,6 +10112,12 @@
         "@types/react": "*"
       }
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
+      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@storybook/theming": "5.3.19",
     "@types/jasmine": "2.8.2",
     "@types/node": "11.13.0",
+    "@types/resize-observer-browser": "^0.1.7",
     "babel-loader": "8.0.5",
     "carbon-components": "10.58.3",
     "chai": "4.2.0",

--- a/src/tabs/tab-headers.component.ts
+++ b/src/tabs/tab-headers.component.ts
@@ -15,7 +15,6 @@ import {
 	OnInit,
 	ChangeDetectorRef
 } from "@angular/core";
-import { EventService } from "carbon-components-angular/utils";
 import { I18n } from "carbon-components-angular/i18n";
 import { Tab } from "./tab.component";
 
@@ -228,7 +227,6 @@ export class TabHeaders implements AfterContentInit, OnChanges, OnDestroy, OnIni
 	constructor(
 		protected elementRef: ElementRef,
 		protected changeDetectorRef: ChangeDetectorRef,
-		protected eventService: EventService,
 		protected i18n: I18n
 	) { }
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -22,7 +22,8 @@
 		],
 		"types": [
 			"jasmine",
-			"node"
+			"node",
+			"resize-observer-browser"
 		],
 		"paths": {
 			"carbon-components-angular": [


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#

The tab headers component doesn't handle view resize event and reset scroll properly, which can cause display issues on view resize. This PR fixes that using `ResizeObserver`.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
