### PR TITLE
fix: Improve grid performance by  preventing unnecessary change detection

### DIFF
--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -5,3 +5,147 @@ html {
 	height: 100%;
 	@include styles.theme(styles.$white);
 }
+
+/*
+ * Story batch styling, we are wrapping the storybook decorator function to ensure
+ * styles do not leak to other components
+ *
+ * To enable this in stories, pass a component wrapper decorator function in Meta as such:
+ * ```
+ * componentWrapperDecorator((story) => `<div class="css-grid-story">${story}</div>`)
+ * ```
+ *
+ * Styling retrieved from:
+ * https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Grid
+ */
+ // Css Grid
+.css-grid-story {
+	.cds--css-grid {
+		background-color: styles.$blue-20;
+		outline: 1px dashed styles.$blue-40;
+	}
+
+	.cds--css-grid p {
+		@include styles.type-style('code-02');
+	}
+
+	.cds--css-grid p:first-of-type {
+		margin-top: 0;
+	}
+
+	.cds--css-grid.cds--css-grid--narrow {
+		background-color: #d6f9f9;
+		outline: 1px dashed styles.$green-40;
+	}
+
+	.cds--css-grid.cds--css-grid--condensed {
+		background-color: styles.$purple-10;
+		outline: 1px dashed styles.$purple-40;
+	}
+
+	.cds--subgrid {
+		outline: 1px solid black;
+		padding-top: 2rem;
+		padding-bottom: 2rem;
+		position: relative;
+		background: #eef4ff;
+	}
+
+	.cds--css-grid,
+	.cds--subgrid--wide {
+		--grid-mode-color: #97c1ff;
+	}
+
+	.cds--css-grid--narrow,
+	.cds--subgrid--narrow {
+		--grid-mode-color: #20d5d2;
+		background: styles.$green-10;
+	}
+
+	.cds--css-grid--condensed,
+	.cds--subgrid--condensed {
+		--grid-mode-color: #bb8eff;
+		background: styles.$purple-10;
+	}
+
+	.cds--subgrid--narrow {
+		background: #d6f9f9;
+	}
+
+	.cds--subgrid--condensed {
+		background: #f7f2ff;
+	}
+
+	.cds--subgrid::before {
+		@include styles.type-style('code-01');
+		position: absolute;
+		inset-block-start: 0;
+		inset-inline-start: 0;
+		display: block;
+		content: 'subgrid';
+		background: var(--grid-mode-color, #97c1ff);
+		color: styles.$black;
+		padding: 0.125rem 0.25rem;
+	}
+
+	.cds--css-grid-column {
+		--border-color: #97c1ff;
+
+		background: white;
+		box-shadow: 0 0 0 1px var(--border-color);
+		min-height: 80px;
+	}
+
+	.cds--css-grid--narrow .cds--css-grid-column,
+	.cds--subgrid--narrow .cds--css-grid-column {
+		--border-color: #20d5d2;
+	}
+
+	.cds--css-grid--condensed .cds--css-grid-column,
+	.cds--subgrid--condensed .cds--css-grid-column {
+		--border-color: #bb8eff;
+	}
+}
+
+// Flex Grid
+.flex-grid-story {
+	.cds--grid [class*='col'] {
+		background-color: styles.$blue-20;
+		outline: 1px dashed styles.$blue-40;
+		min-height: 80px;
+	}
+
+	.inside {
+		background-color: styles.$blue-10;
+		height: 100%;
+		width: inherit;
+	}
+
+	.cds--grid--condensed,
+	.cds--row--condensed {
+		background-color: styles.$blue-20;
+		color: styles.$gray-10;
+	}
+
+	.cds--grid--condensed .inside,
+	.cds--row--condensed .inside {
+		background-color: styles.$teal-10;
+	}
+
+	.cds--grid--condensed [class*='col'],
+	.cds--row--condensed [class*='col'] {
+		background-color: styles.$teal-20;
+		outline: 1px dashed styles.$teal-40;
+	}
+
+	.cds--grid--narrow .inside,
+	.cds--row--narrow .inside {
+		background-color: styles.$teal-10;
+	}
+
+	.cds--grid--narrow [class*='col'],
+	.cds--row--narrow [class*='col'] {
+		background-color: styles.$teal-20;
+		outline: 1px dashed styles.$teal-40;
+	}
+}

--- a/src/grid/column.directive.ts
+++ b/src/grid/column.directive.ts
@@ -1,0 +1,161 @@
+import {
+	Directive,
+	HostBinding,
+	Input,
+	OnChanges,
+	OnDestroy,
+	OnInit,
+	Optional
+} from "@angular/core";
+import { Subscription } from "rxjs";
+import { GridService } from "./grid.service";
+
+@Directive({
+	selector: "[cdsCol], [ibmCol]"
+})
+export class ColumnDirective implements OnInit, OnChanges, OnDestroy {
+	@HostBinding("class")
+	get columnClasses(): string {
+		return this._columnClasses.join(" ");
+	}
+	set columnClasses(classes: string) {
+		this._columnClasses = classes.split(" ");
+	}
+
+	@Input() class = "";
+
+	/**
+	 * Defines columns width for specified breakpoint
+	 * Accepts the following formats:
+	 * - {[breakpoint]: number}
+	 * - {[breakpoint]: "auto"} - css only
+	 * - {[breakpoint]: {[start|end]: number}} - css only
+	 *
+	 * Example:
+	 * <div cdsCol [columnNumbers]={md: 3, lg: 4}></div>
+	 */
+	@Input() columnNumbers = {};
+
+	/**
+	 * Defines columns offset, which increases the left margin of the column.
+	 * This field will only work with flexbox grid.
+	 *
+	 * Accepts the following formats:
+	 * - {[breakpoint]: number}
+	 *
+	 * Example:
+	 * <div cdsCol [offsets]={md: 3, lg: 4}></div>
+	 */
+	@Input() offsets = {};
+
+	/**
+	 * Set to `true` to use css grid column hang class
+	 * This will only work when `isCss` property is set to true
+	 *
+	 * Useful when trying to align content across css grid/subgrid
+	 */
+	@Input() columnHang = false;
+
+	protected _columnClasses: string[] = [];
+
+	private isCssGrid = false;
+	private subscription = new Subscription();
+
+	constructor(@Optional() private gridService: GridService) {}
+
+	ngOnInit() {
+		if (this.gridService) {
+			this.gridService.gridObservable.subscribe((isCssGrid: boolean) => {
+				this.isCssGrid = isCssGrid;
+				this.updateColumnClasses();
+			});
+		} else {
+			this.updateColumnClasses();
+		}
+	}
+
+	ngOnChanges() {
+		this.updateColumnClasses();
+	}
+
+	/**
+	 * Unsubscribe from subscription
+	 */
+	ngOnDestroy() {
+		this.subscription.unsubscribe();
+	}
+
+	private updateColumnClasses() {
+		try {
+			this._columnClasses = [];
+			const columnKeys = Object.keys(this.columnNumbers);
+			console.log(columnKeys);
+
+			// Assign classes based on the type of grid used.
+			if (this.isCssGrid) {
+				// Default css grid class
+				this._columnClasses.push("cds--css-grid-column");
+				if (this.columnHang) {
+					this._columnClasses.push("cds--grid-column-hang");
+				}
+
+				columnKeys.forEach(key => {
+					/**
+					 * Passing in `auto` to a breakpoint as such: {'md': 'auto'}
+					 * will assign the element which will automatically determine the width of the column
+					 * for the breakpoint passed
+					 */
+					if (this.columnNumbers[key] === "auto") {
+						this._columnClasses.push(`cds--${key}:col-span-auto`);
+					} else if (typeof this.columnNumbers[key] === "object") {
+						/**
+						 * In css grid, objects can be passed to the keys in the following format:
+						 * {'md': {'start': 3}}
+						 *
+						 * These objects are used to position the column
+						 */
+						if (this.columnNumbers[key]["start"]) {
+							// col-start is simular equivalent of flex offset
+							this._columnClasses.push(`cds--${key}:col-start-${this.columnNumbers[key].start}`);
+						}
+						if (this.columnNumbers[key]["end"]) {
+							this._columnClasses.push(`cds--${key}:col-end-${this.columnNumbers[key].end}`);
+						}
+						if (this.columnNumbers[key]["span"]) {
+							this._columnClasses.push(`cds--${key}:col-span-${this.columnNumbers[key].span}`);
+						}
+					} else {
+						this._columnClasses.push(`cds--${key}:col-span-${this.columnNumbers[key]}`);
+					}
+				});
+			} else {
+				// Set column classes for flex grid
+				if (columnKeys.length <= 0) {
+					this._columnClasses.push("cds--col");
+				}
+
+				columnKeys.forEach(key => {
+					if (this.columnNumbers[key] === "nobreak") {
+						this._columnClasses.push(`cds--col-${key}`);
+					} else {
+						this._columnClasses.push(`cds--col-${key}-${this.columnNumbers[key]}`);
+					}
+				});
+
+				Object.keys(this.offsets).forEach(key => {
+					this._columnClasses.push(`cds--start-${key}-${this.offsets[key] + 1}`);
+				});
+			}
+		} catch (err) {
+			console.error(`Malformed \`offsets\` or \`columnNumbers\`: ${err}`);
+		}
+
+		/**
+		 * Append the classes passed so they aren't overriden when we set the column classes
+		 * from host binding
+		 */
+		if (this.class) {
+			this._columnClasses.push(this.class);
+		}
+	}
+}

--- a/src/grid/column.directive.ts
+++ b/src/grid/column.directive.ts
@@ -128,6 +128,10 @@ export class ColumnDirective implements OnInit, OnChanges, OnDestroy {
 						this._columnClasses.push(`cds--${key}:col-span-${this.columnNumbers[key]}`);
 					}
 				});
+
+				Object.keys(this.offsets).forEach(key => {
+					this._columnClasses.push(`cds--${key}:col-start${this.offsets[key]}`);
+				});
 			} else {
 				// Set column classes for flex grid
 				if (columnKeys.length <= 0) {

--- a/src/grid/column.directive.ts
+++ b/src/grid/column.directive.ts
@@ -89,7 +89,6 @@ export class ColumnDirective implements OnInit, OnChanges, OnDestroy {
 		try {
 			this._columnClasses = [];
 			const columnKeys = Object.keys(this.columnNumbers);
-			console.log(columnKeys);
 
 			// Assign classes based on the type of grid used.
 			if (this.isCssGrid) {
@@ -130,7 +129,7 @@ export class ColumnDirective implements OnInit, OnChanges, OnDestroy {
 				});
 
 				Object.keys(this.offsets).forEach(key => {
-					this._columnClasses.push(`cds--${key}:col-start${this.offsets[key]}`);
+					this._columnClasses.push(`cds--${key}:col-start${this.offsets[key] + 1}`);
 				});
 			} else {
 				// Set column classes for flex grid
@@ -147,7 +146,7 @@ export class ColumnDirective implements OnInit, OnChanges, OnDestroy {
 				});
 
 				Object.keys(this.offsets).forEach(key => {
-					this._columnClasses.push(`cds--start-${key}-${this.offsets[key] + 1}`);
+					this._columnClasses.push(`cds--offset-${key}-${this.offsets[key]}`);
 				});
 			}
 		} catch (err) {

--- a/src/grid/css-grid.stories.ts
+++ b/src/grid/css-grid.stories.ts
@@ -1,0 +1,172 @@
+/* tslint:disable variable-name */
+
+import { moduleMetadata, componentWrapperDecorator } from "@storybook/angular";
+import { Story, Meta } from "@storybook/angular/types-6-0";
+import {
+	GridModule,
+	GridDirective,
+	RowDirective,
+	ColumnDirective
+} from "./";
+
+export default {
+	title: "Components/Grid/CSS",
+	decorators: [
+		moduleMetadata({
+			imports: [GridModule]
+		}),
+		componentWrapperDecorator((story) => `<div class="css-grid-story">${story}</div>`)
+	],
+	component: GridDirective,
+	subcomponents: {
+		RowDirective,
+		ColumnDirective
+	},
+	argTypes: {
+		useCssGrid: {
+			control: false
+		}
+	}
+} as Meta;
+
+const Template: Story<GridDirective> = (args) => ({
+	props: args,
+	template: `
+		<div
+			cdsGrid
+			[useCssGrid]="true"
+			[condensed]="condensed"
+			[narrow]="narrow"
+			[fullWidth]="fullWidth">
+			<div cdsCol [columnNumbers]="{sm: 4}"></div>
+			<div cdsCol [columnNumbers]="{sm: 4}"></div>
+			<div cdsCol [columnNumbers]="{sm: 4}"></div>
+			<div cdsCol [columnNumbers]="{sm: 4}"></div>
+		</div>
+	`
+});
+export const Basic = Template.bind({});
+
+const GridStartTemplate: Story<GridDirective> = (args) => ({
+	props: args,
+	template: `
+		<div
+			cdsGrid
+			[useCssGrid]="true"
+			[condensed]="condensed"
+			[narrow]="narrow"
+			[fullWidth]="fullWidth">
+			<div cdsCol [columnNumbers]="{
+				sm: {span: 1, start: 4},
+				md: {span: 2, start: 7},
+				lg: {span: 4, start: 13}
+			}">span, start</div>
+			<div cdsCol [columnNumbers]="{
+				sm: {span: 2, end: 5},
+				md: {span: 4, end: 9},
+				lg: {span: 8, end: 17}
+			}">span, end</div>
+			<div cdsCol [columnNumbers]="{
+				sm: {start: 1, end: 4},
+				md: {start: 3, end: 7},
+				lg: {start: 5, end: 17}
+			}">start, end</div>
+		</div>
+	`
+});
+export const GridStart = GridStartTemplate.bind({});
+
+const ResponsiveTemplate: Story<GridDirective> = (args) => ({
+	props: args,
+	template: `
+		<div
+			cdsGrid
+			[useCssGrid]="true"
+			[condensed]="condensed"
+			[narrow]="narrow"
+			[fullWidth]="fullWidth">
+			<div cdsCol [columnNumbers]="{sm: 2, md: 4, lg: 6}">
+				<p>Small: Span 2 of 4</p>
+				<p>Medium: Span 4 of 8</p>
+				<p>Large: Span 6 of 16</p>
+			</div>
+			<div cdsCol [columnNumbers]="{sm: 2, md: 2, lg: 3}">
+				<p>Small: Span 2 of 4</p>
+				<p>Medium: Span 2 of 8</p>
+				<p>Large: Span 3 of 16</p>
+			</div>
+			<div cdsCol [columnNumbers]="{sm: 0, md: 2, lg: 3}">
+				<p>Small: Span 0 of 4</p>
+				<p>Medium: Span 2 of 8</p>
+				<p>Large: Span 3 of 16</p>
+			</div>
+			<div cdsCol [columnNumbers]="{sm: 0, md: 0, lg: 4}">
+				<p>Small: Span 0 of 4</p>
+				<p>Medium: Span 0 of 8</p>
+				<p>Large: Span 4 of 16</p>
+			</div>
+			<div cdsCol [columnNumbers]="{sm: 25, md: 50, lg: 75}">
+				<p>Small: Span 25%</p>
+				<p>Medium: Span 50%</p>
+				<p>Large: 75%</p>
+			</div>
+		</div>
+	`
+});
+export const Responsive = ResponsiveTemplate.bind({});
+
+const SubgridTemplate: Story<GridDirective> = (args) => ({
+	props: args,
+	template: `
+		<div
+			cdsGrid
+			[useCssGrid]="true"
+			[condensed]="condensed"
+			[narrow]="narrow"
+			[fullWidth]="fullWidth">
+			<div cdsCol [columnNumbers]="{sm: 2, md: 4, lg: 3}">
+				<p>Small: Span 2 of 4</p>
+				<p>Medium: Span 4 of 8</p>
+				<p>Large: Span 3 of 16</p>
+			</div>
+			<div cdsCol [columnNumbers]="{sm: 2, md: 4, lg: 10}">
+				<p>Small: Span 2 of 4</p>
+				<p>Medium: Span 2 of 8</p>
+				<p>Large: Span 10 of 16</p>
+				<div cdsGrid>
+					<div cdsCol [columnNumbers]="{sm: 1, md: 1, lg: 2}">
+						<p>sm:1</p>
+						<p>md:1</p>
+						<p>lg:2</p>
+					</div>
+					<div cdsCol [columnNumbers]="{sm: 1, md: 1, lg: 2}">
+						<p>sm:1</p>
+						<p>md:1</p>
+						<p>lg:2</p>
+					</div>
+					<div cdsCol [columnNumbers]="{sm: 0, md: 1, lg: 1}">
+						<p>sm:0</p>
+						<p>md:1</p>
+						<p>lg:1</p>
+					</div>
+					<div cdsCol [columnNumbers]="{sm: 0, md: 1, lg: 1}">
+						<p>sm:0</p>
+						<p>md:1</p>
+						<p>lg:1</p>
+					</div>
+					<div cdsCol [columnNumbers]="{sm: 0, md: 0, lg: 4}">
+						<p>sm:0</p>
+						<p>md:0</p>
+						<p>lg:4</p>
+					</div>
+				</div>
+			</div>
+			<div cdsCol [columnNumbers]="{sm: 0, md: 0, lg: 3}">
+				<p>Small: Span 0 of 4</p>
+				<p>Medium: Span 0 of 8</p>
+				<p>Large: Span 3 of 16</p>
+			</div>
+		</div>
+	`
+});
+export const Subgrid = SubgridTemplate.bind({});

--- a/src/grid/grid.directive.spec.ts
+++ b/src/grid/grid.directive.spec.ts
@@ -7,7 +7,10 @@ import {
 	flush
 } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { ColumnDirective, GridDirective, RowDirective } from "./grid.directive";
+
+import { ColumnDirective } from "./column.directive";
+import { RowDirective } from "./row.directive";
+import { GridDirective } from "./grid.directive";
 
 @Component({
 	selector: "cds-test-grid",
@@ -147,7 +150,6 @@ describe("GridDirective", () => {
 				By.directive(ColumnDirective)
 			);
 
-			tick(100);
 			fixture.detectChanges();
 			fixture.whenStable().then(() => {
 				expect(directiveEl).not.toBeNull();

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -1,235 +1,124 @@
 import {
-	AfterContentInit,
 	ContentChildren,
 	Directive,
 	HostBinding,
 	Input,
-	OnChanges,
+	OnDestroy,
+	OnInit,
+	Optional,
 	QueryList,
-	AfterViewInit
+	SkipSelf
 } from "@angular/core";
-
-@Directive({
-	selector: "[cdsCol], [ibmCol]"
-})
-export class ColumnDirective implements AfterViewInit, OnChanges {
-	@HostBinding("class")
-	get columnClasses(): string {
-		return this._columnClasses.join(" ");
-	}
-	set columnClasses(classes: string) {
-		this._columnClasses = classes.split(" ");
-	}
-
-	@Input() class = "";
-
-	/**
-	 * Defines columns width for specified breakpoint
-	 * Accepts the following formats:
-	 * - {[breakpoint]: number}
-	 * - {[breakpoint]: "auto"} - css only
-	 * - {[breakpoint]: {[start|end]: number}} - css only
-	 *
-	 * Example:
-	 * <div cdsCol [columnNumbers]={md: 3, lg: 4}></div>
-	 */
-	@Input() columnNumbers = {};
-
-	/**
-	 * Defines columns offset, which increases the left margin of the column.
-	 * This field will only work with flexbox grid.
-	 *
-	 * Accepts the following formats:
-	 * - {[breakpoint]: number}
-	 *
-	 * Example:
-	 * <div cdsCol [offsets]={md: 3, lg: 4}></div>
-	 */
-	@Input() offsets = {};
-
-	/**
-	 * Set to `true` to use css grid column hang class
-	 * This will only work when `isCss` property is set to true
-	 *
-	 * Useful when trying to align content across css grid/subgrid
-	 */
-	@Input() columnHang = false;
-
-	isCss = false;
-
-	protected _columnClasses: string[] = [];
-
-	ngAfterViewInit() {
-		this.updateColumnClasses();
-	}
-
-	ngOnChanges() {
-		this.updateColumnClasses();
-	}
-
-	private updateColumnClasses() {
-		try {
-			this._columnClasses = [];
-			const columnKeys = Object.keys(this.columnNumbers);
-
-			// Assign classes based on the type of grid used.
-			if (this.isCss) {
-				// Default css grid class
-				this._columnClasses.push("cds--css-grid-column");
-				if (this.columnHang) {
-					this._columnClasses.push("cds--grid-column-hang");
-				}
-
-				columnKeys.forEach(key => {
-					/**
-					 * Passing in `auto` to a breakpoint as such: {'md': 'auto'}
-					 * will assign the element which will automatically determine the width of the column
-					 * for the breakpoint passed
-					 */
-					if (this.columnNumbers[key] === "auto") {
-						this._columnClasses.push(`cds--${key}:col-span-auto`);
-					} else if (typeof this.columnNumbers[key] === "object") {
-						/**
-						 * In css grid, objects can be passed to the keys in the following format:
-						 * {'md': {'start': 3}}
-						 *
-						 * These objects are used to position the column
-						 */
-						if (this.columnNumbers[key]["start"]) {
-							// col-start is simular equivalent of flex offset
-							this._columnClasses.push(`cds--${key}:col-start-${this.columnNumbers[key]}`);
-						} else if (this.columnNumbers[key]["end"]) {
-							this._columnClasses.push(`cds--${key}:col-end-${this.columnNumbers[key]}`);
-						}
-					} else {
-						this._columnClasses.push(`cds--${key}:col-span-${this.columnNumbers[key]}`);
-					}
-				});
-			} else {
-				// Set column classes for flex grid
-				if (columnKeys.length <= 0) {
-					this._columnClasses.push("cds--col");
-				}
-
-				columnKeys.forEach(key => {
-					if (this.columnNumbers[key] === "nobreak") {
-						this._columnClasses.push(`cds--col-${key}`);
-					} else {
-						this._columnClasses.push(`cds--col-${key}-${this.columnNumbers[key]}`);
-					}
-				});
-
-				Object.keys(this.offsets).forEach(key => {
-					this._columnClasses.push(`cds--offset-${key}-${this.offsets[key]}`);
-				});
-			}
-		} catch (err) {
-			console.error(`Malformed \`offsets\` or \`columnNumbers\`: ${err}`);
-		}
-
-		/**
-		 * Append the classes passed so they aren't overriden when we set the column classes
-		 * from host binding
-		 */
-		if (this.class) {
-			this._columnClasses.push(this.class);
-		}
-	}
-}
-
-@Directive({
-	selector: "[cdsRow], [ibmRow]"
-})
-export class RowDirective {
-	@HostBinding("class.cds--row") baseClass = true;
-	@HostBinding("class.cds--row--condensed") @Input() condensed = false;
-	@HostBinding("class.cds--row--narrow") @Input() narrow = false;
-}
+import { Subscription } from "rxjs";
+import { GridService } from "./grid.service";
 
 /**
  * [See demo](../../?path=/story/components-grid--basic)
  */
 @Directive({
-	selector: "[cdsGrid], [ibmGrid]"
+	selector: "[cdsGrid], [ibmGrid]",
+	providers: [
+		{
+			provide: GridService,
+			deps: [[new Optional(), new SkipSelf(), GridService]],
+			useFactory: (parentService: GridService) => {
+				return parentService || new GridService();
+			}
+		}
+	]
 })
-export class GridDirective implements AfterContentInit {
+export class GridDirective implements OnInit, OnDestroy {
+	/**
+	 * Set to `true` to condense the grid
+	 */
 	@Input() condensed = false;
+	/**
+	 * Set to `true` to use narrow grid
+	 */
 	@Input() narrow = false;
+	/**
+	 * Set to `true` to use the full width
+	 */
 	@Input() fullWidth = false;
-
 	/**
 	 * Set to `true` to use css grid
 	 */
-	@Input() useCssGrid = false;
+	@Input() set useCssGrid(enable: boolean) {
+		this.cssGridEnabled = enable;
+		this.gridService.updateGridType(enable);
+	}
+
+	private cssGridEnabled = false;
+	private isSubgrid = false;
+	private subscription = new Subscription();
 
 	// Flex grid
 	@HostBinding("class.cds--grid") get flexGrid() {
-		return !this.useCssGrid;
+		return !this.cssGridEnabled;
 	}
 	@HostBinding("class.cds--grid--condensed") get flexCondensed() {
-		return !this.useCssGrid && this.condensed;
+		return !this.cssGridEnabled && this.condensed;
 	}
 	@HostBinding("class.cds--grid--narrow") get flexNarrow() {
-		return !this.useCssGrid && this.narrow;
+		return !this.cssGridEnabled && this.narrow;
 	}
 	@HostBinding("class.cds--grid--full-width") get flexFullWidth() {
-		return !this.useCssGrid && this.fullWidth;
+		return !this.cssGridEnabled && this.fullWidth;
 	}
 
 	// CSS Grid
 	@HostBinding("class.cds--css-grid") get ccsGrid() {
-		return this.useCssGrid && !this.isSubgrid;
+		return this.cssGridEnabled && !this.isSubgrid;
 	}
 	@HostBinding("class.cds--css-grid--condensed") get ccsCondensed() {
-		return this.useCssGrid && !this.isSubgrid && this.condensed;
+		return this.cssGridEnabled && !this.isSubgrid && this.condensed;
 	}
 	@HostBinding("class.cds--css-grid--narrow") get ccsNarrow() {
-		return this.useCssGrid && !this.isSubgrid && this.narrow;
+		return this.cssGridEnabled && !this.isSubgrid && this.narrow;
 	}
 	@HostBinding("class.cds--css-grid--full-width") get ccsFullWidth() {
-		return this.useCssGrid && !this.isSubgrid && this.fullWidth;
+		return this.cssGridEnabled && !this.isSubgrid && this.fullWidth;
 	}
 
 	// CSS Sub Grid
 	@HostBinding("class.cds--subgrid") get subGrid() {
-		return this.useCssGrid && this.isSubgrid;
+		return this.cssGridEnabled && this.isSubgrid;
 	}
 	@HostBinding("class.cds--subgrid--condensed") get subCondensed() {
-		return this.useCssGrid && this.isSubgrid && this.condensed;
+		return this.cssGridEnabled && this.isSubgrid && this.condensed;
 	}
 	@HostBinding("class.cds--subgrid--narrow") get subNarrow() {
-		return this.useCssGrid && this.isSubgrid && this.narrow;
+		return this.cssGridEnabled && this.isSubgrid && this.narrow;
 	}
 	@HostBinding("class.cds--subgrid--wide") get subFullWidth() {
-		return this.useCssGrid && this.isSubgrid && this.fullWidth;
+		return this.cssGridEnabled && this.isSubgrid && this.fullWidth;
 	}
 
-	@ContentChildren(GridDirective, { descendants: true }) cssGridChildren: QueryList<GridDirective>;
-	@ContentChildren(ColumnDirective, { descendants: true }) columnChildren: QueryList<ColumnDirective>;
+	constructor(private gridService: GridService) {}
 
-	private isSubgrid = false;
+	ngOnInit() {
+		this.subscription = this.gridService.gridObservable.subscribe((isCssGrid: boolean) => {
+			this.cssGridEnabled = isCssGrid;
+		});
+	}
 
-	ngAfterContentInit(): void {
-		if (typeof this.useCssGrid !== "boolean") {
-			this.useCssGrid = false;
+	// Make all children grids a sub grid
+	@ContentChildren(GridDirective, { descendants: true }) set cssGridChildren(list: QueryList<GridDirective>) {
+		if (this.cssGridEnabled) {
+			list.forEach((grid) => {
+				// Prevents initial (parent) grid element from being turned into a subgrid
+				if (grid === this) {
+					return;
+				}
+				grid.isSubgrid = true;
+			});
 		}
+	}
 
-		// Update children grid & columns to use css grid classes
-		if (this.useCssGrid) {
-			if (this.cssGridChildren) {
-				this.cssGridChildren.forEach((grid) => {
-					// Prevents initial (parent) grid element from being turned into a subgrid
-					if (grid === this) {
-						return;
-					}
-					grid.useCssGrid = true;
-					grid.isSubgrid = true;
-				});
-			}
-
-			if (this.columnChildren) {
-				this.columnChildren.forEach(column => column.isCss = true);
-			}
-		}
+	/**
+	 * Unsubscribe from Grid Service subscription
+	 */
+	ngOnDestroy() {
+		this.subscription.unsubscribe();
 	}
 }

--- a/src/grid/grid.directive.ts
+++ b/src/grid/grid.directive.ts
@@ -5,14 +5,14 @@ import {
 	HostBinding,
 	Input,
 	OnChanges,
-	OnInit,
-	QueryList
+	QueryList,
+	AfterViewInit
 } from "@angular/core";
 
 @Directive({
 	selector: "[ibmCol]"
 })
-export class ColumnDirective implements OnInit, OnChanges {
+export class ColumnDirective implements AfterViewInit, OnChanges {
 	@HostBinding("class")
 	get columnClasses(): string {
 		return this._columnClasses.join(" ");
@@ -59,7 +59,7 @@ export class ColumnDirective implements OnInit, OnChanges {
 
 	protected _columnClasses: string[] = [];
 
-	ngOnInit() {
+	ngAfterViewInit() {
 		this.updateColumnClasses();
 	}
 
@@ -68,76 +68,72 @@ export class ColumnDirective implements OnInit, OnChanges {
 	}
 
 	private updateColumnClasses() {
-		// Using setTimeout to simulate a tick to capture an update isCss property
-		// otherwise, isCss will always be false
-		setTimeout(() => {
-			try {
-				this._columnClasses = [];
-				const columnKeys = Object.keys(this.columnNumbers);
+		try {
+			this._columnClasses = [];
+			const columnKeys = Object.keys(this.columnNumbers);
 
-				// Assign classes based on the type of grid used.
-				if (this.isCss) {
-					// Default css grid class
-					this._columnClasses.push("cds--css-grid-column");
-					if (this.columnHang) {
-						this._columnClasses.push("cds--grid-column-hang");
-					}
-
-					columnKeys.forEach(key => {
-						/**
-						 * Passing in `auto` to a breakpoint as such: {'md': 'auto'}
-						 * will assign the element which will automatically determine the width of the column
-						 * for the breakpoint passed
-						 */
-						if (this.columnNumbers[key] === "auto") {
-							this._columnClasses.push(`cds--${key}:col-span-auto`);
-						} else if (typeof this.columnNumbers[key] === "object") {
-							/**
-							 * In css grid, objects can be passed to the keys in the following format:
-							 * {'md': {'start': 3}}
-							 *
-							 * These objects are used to position the column
-							 */
-							if (this.columnNumbers[key]["start"]) {
-								// col-start is simular equivalent of flex offset
-								this._columnClasses.push(`cds--${key}:col-start-${this.columnNumbers[key]}`);
-							} else if (this.columnNumbers[key]["end"]) {
-								this._columnClasses.push(`cds--${key}:col-end-${this.columnNumbers[key]}`);
-							}
-						} else {
-							this._columnClasses.push(`cds--${key}:col-span-${this.columnNumbers[key]}`);
-						}
-					});
-				} else {
-					// Set column classes for flex grid
-					if (columnKeys.length <= 0) {
-						this._columnClasses.push("cds--col");
-					}
-
-					columnKeys.forEach(key => {
-						if (this.columnNumbers[key] === "nobreak") {
-							this._columnClasses.push(`cds--col-${key}`);
-						} else {
-							this._columnClasses.push(`cds--col-${key}-${this.columnNumbers[key]}`);
-						}
-					});
-
-					Object.keys(this.offsets).forEach(key => {
-						this._columnClasses.push(`cds--offset-${key}-${this.offsets[key]}`);
-					});
+			// Assign classes based on the type of grid used.
+			if (this.isCss) {
+				// Default css grid class
+				this._columnClasses.push("cds--css-grid-column");
+				if (this.columnHang) {
+					this._columnClasses.push("cds--grid-column-hang");
 				}
-			} catch (err) {
-				console.error(`Malformed \`offsets\` or \`columnNumbers\`: ${err}`);
-			}
 
-			/**
-			 * Append the classes passed so they aren't overriden when we set the column classes
-			 * from host binding
-			 */
-			if (this.class) {
-				this._columnClasses.push(this.class);
+				columnKeys.forEach(key => {
+					/**
+					 * Passing in `auto` to a breakpoint as such: {'md': 'auto'}
+					 * will assign the element which will automatically determine the width of the column
+					 * for the breakpoint passed
+					 */
+					if (this.columnNumbers[key] === "auto") {
+						this._columnClasses.push(`cds--${key}:col-span-auto`);
+					} else if (typeof this.columnNumbers[key] === "object") {
+						/**
+						 * In css grid, objects can be passed to the keys in the following format:
+						 * {'md': {'start': 3}}
+						 *
+						 * These objects are used to position the column
+						 */
+						if (this.columnNumbers[key]["start"]) {
+							// col-start is simular equivalent of flex offset
+							this._columnClasses.push(`cds--${key}:col-start-${this.columnNumbers[key]}`);
+						} else if (this.columnNumbers[key]["end"]) {
+							this._columnClasses.push(`cds--${key}:col-end-${this.columnNumbers[key]}`);
+						}
+					} else {
+						this._columnClasses.push(`cds--${key}:col-span-${this.columnNumbers[key]}`);
+					}
+				});
+			} else {
+				// Set column classes for flex grid
+				if (columnKeys.length <= 0) {
+					this._columnClasses.push("cds--col");
+				}
+
+				columnKeys.forEach(key => {
+					if (this.columnNumbers[key] === "nobreak") {
+						this._columnClasses.push(`cds--col-${key}`);
+					} else {
+						this._columnClasses.push(`cds--col-${key}-${this.columnNumbers[key]}`);
+					}
+				});
+
+				Object.keys(this.offsets).forEach(key => {
+					this._columnClasses.push(`cds--offset-${key}-${this.offsets[key]}`);
+				});
 			}
-		});
+		} catch (err) {
+			console.error(`Malformed \`offsets\` or \`columnNumbers\`: ${err}`);
+		}
+
+		/**
+		 * Append the classes passed so they aren't overriden when we set the column classes
+		 * from host binding
+		 */
+		if (this.class) {
+			this._columnClasses.push(this.class);
+		}
 	}
 }
 
@@ -157,7 +153,6 @@ export class RowDirective {
 	selector: "[ibmGrid]"
 })
 export class GridDirective implements AfterContentInit {
-
 	@Input() condensed = false;
 	@Input() narrow = false;
 	@Input() fullWidth = false;

--- a/src/grid/grid.module.ts
+++ b/src/grid/grid.module.ts
@@ -1,7 +1,10 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
-import { ColumnDirective, GridDirective, RowDirective } from "./grid.directive";
+import { ColumnDirective } from "./column.directive";
+import { RowDirective } from "./row.directive";
+import { GridDirective } from "./grid.directive";
+import { GridService } from "./grid.service";
 
 @NgModule({
 	declarations: [
@@ -14,6 +17,7 @@ import { ColumnDirective, GridDirective, RowDirective } from "./grid.directive";
 		GridDirective,
 		RowDirective
 	],
+	providers: [GridService],
 	imports: [CommonModule]
 })
-export class GridModule { }
+export class GridModule {}

--- a/src/grid/grid.service.ts
+++ b/src/grid/grid.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+
+@Injectable()
+export class GridService {
+	public gridObservable: Observable<any | any[]>;
+	private gridSubject = new BehaviorSubject<boolean>(false);
+	private cssGridEnabled = false;
+
+	constructor() {
+		this.gridObservable = this.gridSubject.asObservable();
+	}
+
+	/**
+	 * Ping all subscribers to update to use Css Grid
+	 * @param enableCssGrid
+	 */
+	updateGridType(enableCssGrid: boolean) {
+		if (this.cssGridEnabled === enableCssGrid) {
+			return;
+		}
+
+		this.cssGridEnabled = true;
+		this.gridSubject.next(enableCssGrid);
+	}
+}

--- a/src/grid/grid.stories.ts
+++ b/src/grid/grid.stories.ts
@@ -1,6 +1,6 @@
 /* tslint:disable variable-name */
 
-import { moduleMetadata } from "@storybook/angular";
+import { moduleMetadata, componentWrapperDecorator } from "@storybook/angular";
 import { Story, Meta } from "@storybook/angular/types-6-0";
 import {
 	GridModule,
@@ -10,49 +10,163 @@ import {
 } from "./";
 
 export default {
-	title: "Components/Grid",
+	title: "Components/Grid/Flex",
 	decorators: [
 		moduleMetadata({
 			imports: [GridModule]
-		})
+		}),
+		componentWrapperDecorator((story) => `<div class="flex-grid-story">${story}</div>`)
 	],
 	component: GridDirective,
 	subcomponents: {
 		RowDirective,
 		ColumnDirective
+	},
+	argTypes: {
+		useCssGrid: {
+			control: false
+		}
 	}
 } as Meta;
 
 const Template: Story<GridDirective> = (args) => ({
 	props: args,
 	template: `
-		<div cdsGrid [condensed]="gridCondensed">
-			<div
-				cdsRow
-				[gutter]="gutter"
-				[condensed]="rowCondensed">
-				<div cdsCol class="custom-class-example" [columnNumbers]="{md: 2, sm: 4}">First Column</div>
-				<div cdsCol class="custom-class-example" [columnNumbers]="{md: 2, sm: 4}">Second column</div>
-				<div cdsCol class="custom-class-example" [columnNumbers]="{md: 2, sm: 4}">Third Column</div>
+		<div
+			cdsGrid
+			[condensed]="condensed"
+			[fullWidth]="fullWidth"
+			[narrow]="narrow">
+			<div cdsRow>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
 			</div>
 		</div>
 	`
 });
 export const Basic = Template.bind({});
-Basic.args = {
-	gutter: true,
-	rowCondensed: false,
-	gridCondensed: false
-};
 
-const CSSGridTemplate: Story<GridDirective> = (args) => ({
+const ResponsiveTemplate: Story<GridDirective> = (args) => ({
 	props: args,
 	template: `
-		<div cdsGrid [condensed]="gridCondensed" [useCssGrid]="true">
-			<div cdsCol class="custom-class-example" [columnNumbers]="{md: 2, sm: 4}">First Column</div>
-			<div cdsCol class="custom-class-example" [columnNumbers]="{md: 2, sm: 4}">Second column</div>
-			<div cdsCol class="custom-class-example" [columnNumbers]="{md: 2, sm: 4}">Third Column</div>
+		<div cdsGrid [condensed]="gridCondensed">
+			<div
+				cdsRow
+				[condensed]="rowCondensed">
+				<div cdsCol class="custom-class-example" [columnNumbers]="{sm: 2, md: 4, lg: 6}">
+					<div class="inside">
+						<p>Small: Span 2 of 4</p>
+						<p>Medium: Span 4 of 8</p>
+						<p>Large: Span 6 of 16</p>
+					</div>
+				</div>
+				<div cdsCol class="custom-class-example" [columnNumbers]="{sm: 2, md: 2, lg: 3}">
+					<div class="inside">
+						<p>Small: Span 2 of 4</p>
+						<p>Medium: Span 2 of 8</p>
+						<p>Large: Span 3 of 16</p>
+					</div>
+				</div>
+				<div cdsCol class="custom-class-example" [columnNumbers]="{sm: 0, md: 2, lg: 3}">
+					<div class="inside">
+						<p>Small: Span 0 of 4</p>
+						<p>Medium: Span 2 of 8</p>
+						<p>Large: Span 3 of 16</p>
+					</div>
+				</div>
+			</div>
 		</div>
 	`
 });
-export const CssGrid = CSSGridTemplate.bind({});
+export const Responsive = ResponsiveTemplate.bind({});
+
+const OffsetTemplate: Story<GridDirective> = (args) => ({
+	props: args,
+	template: `
+		<div
+			cdsGrid
+			[condensed]="condensed"
+			[fullWidth]="fullWidth"
+			[narrow]="narrow">
+			<div cdsRow>
+				<div cdsCol class="custom-class-example" [columnNumbers]="{sm: 1}" [offsets]="{sm: 3}">
+					<div class="inside">Small: Offset 3</div>
+				</div>
+				<div cdsCol class="custom-class-example" [columnNumbers]="{sm: 2}" [offsets]="{sm: 2}">
+					<div class="inside">Small: Offset 2</div>
+				</div>
+				<div cdsCol class="custom-class-example" [columnNumbers]="{sm: 3}" [offsets]="{sm: 1}">
+					<div class="inside">Small: Offset 1</div>
+				</div>
+				<div cdsCol class="custom-class-example" [columnNumbers]="{sm: 4}" [offsets]="{sm: 0}">
+					<div class="inside">Small: Offset -</div>
+				</div>
+			</div>
+		</div>
+	`
+});
+export const Offset = OffsetTemplate.bind({});
+
+const CondensedRowTemplate: Story<GridDirective> = (args) => ({
+	props: args,
+	template: `
+		<div
+			cdsGrid
+			[condensed]="condensed"
+			[fullWidth]="fullWidth"
+			[narrow]="narrow">
+			<div cdsRow [condensed]="true">
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+			</div>
+		</div>
+	`
+});
+export const CondensedRow = CondensedRowTemplate.bind({});
+
+const NarrowRowTemplate: Story<GridDirective> = (args) => ({
+	props: args,
+	template: `
+		<div
+			cdsGrid
+			[condensed]="condensed"
+			[fullWidth]="fullWidth"
+			[narrow]="narrow">
+			<div cdsRow [condensed]="true" [narrow]="true">
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+				<div cdsCol class="custom-class-example">
+					<div class="inside">Span 25%</div>
+				</div>
+			</div>
+		</div>
+	`
+});
+export const NarrowRow = NarrowRowTemplate.bind({});

--- a/src/grid/index.ts
+++ b/src/grid/index.ts
@@ -1,2 +1,5 @@
 export * from "./grid.module";
 export * from "./grid.directive";
+export * from "./grid.service";
+export * from "./row.directive";
+export * from "./column.directive";

--- a/src/grid/row.directive.ts
+++ b/src/grid/row.directive.ts
@@ -1,0 +1,14 @@
+import {
+	Directive,
+	HostBinding,
+	Input
+} from "@angular/core";
+
+@Directive({
+	selector: "[cdsRow], [ibmRow]"
+})
+export class RowDirective {
+	@HostBinding("class.cds--row") baseClass = true;
+	@HostBinding("class.cds--row--condensed") @Input() condensed = false;
+	@HostBinding("class.cds--row--narrow") @Input() narrow = false;
+}


### PR DESCRIPTION
#### Changelog

**Changed**

* Assigning initial column classes after view initializes instead of ngOnInit to remove unnecessary SetTimeout which would trigger changeDetection for all child components.
