### PR TITLE
fix: Remove invalid aria-checked property in template

### DIFF
--- a/src/toggle/toggle.component.spec.ts
+++ b/src/toggle/toggle.component.spec.ts
@@ -52,7 +52,7 @@ describe("Toggle", () => {
 		expect(buttonElement.className.includes("bx--toggle-input--small")).toEqual(true);
 	});
 
-	fit("should match the input checked value", () => {
+	it("should match the input checked value", () => {
 		component.checked = true;
 		fixture.detectChanges();
 		expect(fixture.componentInstance.checked).toEqual(true);

--- a/src/toggle/toggle.component.spec.ts
+++ b/src/toggle/toggle.component.spec.ts
@@ -52,10 +52,10 @@ describe("Toggle", () => {
 		expect(buttonElement.className.includes("bx--toggle-input--small")).toEqual(true);
 	});
 
-	it("should match the input checked value", () => {
+	fit("should match the input checked value", () => {
 		component.checked = true;
 		fixture.detectChanges();
-		expect(buttonElement.attributes.getNamedItem("aria-checked").value).toEqual("true");
+		expect(fixture.componentInstance.checked).toEqual(true);
 	});
 
 	it("should emit ToggleChange event", (done: any) => {

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -73,7 +73,6 @@ export class ToggleChange {
 			[checked]="checked"
 			[disabled]="disabled"
 			[attr.aria-labelledby]="ariaLabelledby"
-			[attr.aria-checked]="checked"
 			(change)="onChange($event)"
 			(click)="onClick($event)"
 			(keyup.enter)="onClick($event)">


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2508

`aria-checked` can only be applied to elements with role `checkbox`

#### Changelog

**Removed**
* Removed invalid accessibility property.

