### PR TITLE
fix: hasScrollingContent condition in modal service

### DIFF
--- a/src/modal/modal.service.ts
+++ b/src/modal/modal.service.ts
@@ -49,7 +49,7 @@ export class ModalService extends BaseModalService {
 				label: data.label,
 				title: data.title,
 				content: data.content,
-				hasScrollingContent: data.hasScrollingContent || null,
+				hasScrollingContent: data.hasScrollingContent !== undefined ? data.hasScrollingContent : null,
 				size: data.size,
 				buttons: data.buttons || [],
 				close: data.close || (() => { }),


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2521

When creating a modal via Modal service, setting `hasScrollingContent: false` has no effect.

`hasScrollingContent: data.hasScrollingContent || null,` 
will be set to `null` if `data.hasScrollingContent = false`

`false || null` => `null`

#### Changelog

**New**

--

**Changed**

a condition in modal service.

**Removed**

--
