### PR TITLE
Fix: file uploader valueChanges event to fire for drag-and-drop

### DIFF
--- a/src/file-uploader/file-uploader.component.ts
+++ b/src/file-uploader/file-uploader.component.ts
@@ -172,7 +172,8 @@ export class FileUploader implements ControlValueAccessor {
 	}
 
 	/**
-	 * Specifies the property to be used as the return value to `ngModel`
+	 * Specifies the property to be used as the return value to `ngModel` and reactive forms.
+	 * Updates `this.files`.
 	 */
 	get value(): Set<FileItem> {
 		return this.files;
@@ -241,7 +242,8 @@ export class FileUploader implements ControlValueAccessor {
 		event.stopPropagation();
 		event.preventDefault();
 
-		const transferredFiles = Array.from(event.dataTransfer.files);
+		const transferredFiles: Array<File> = Array.from(event.dataTransfer.files);
+		const newFiles = new Set<FileItem>(this.files);
 
 		transferredFiles.filter(({ name, type }) => {
 			// Get the file extension and add a "." to the beginning.
@@ -249,27 +251,28 @@ export class FileUploader implements ControlValueAccessor {
 			// Check if the accept array contains the mime type or extension of the file.
 			return this.accept.includes(type) || this.accept.includes(fileExtension) || !this.accept.length;
 		}).forEach(file => {
-			if (!this.files.size || this.multiple) {
+			if (!newFiles.size || this.multiple) {
 				const fileItem = this.createFileItem(file);
-				this.files.add(fileItem);
+				newFiles.add(fileItem);
 			}
 		});
 
-		this.filesChange.emit(this.files);
-		this.value = this.files;
+		this.value = newFiles;
+		this.filesChange.emit(newFiles);
 		this.dragOver = false;
 	}
 
 	removeFile(fileItem) {
-		let shouldEmit = true;
-		if (this.files) {
-			shouldEmit = this.files.has(fileItem);
-			this.files.delete(fileItem);
+		// Deleting an item from this.files removes the <ibm-file> component,
+		// which triggers its ngOnDestroy(), which fires the (remove) event again.
+		// So, (remove) may double-fire and we need to handle it here.
+		if (this.files && this.files.has(fileItem)) {
+			const newFiles = new Set<FileItem>(this.files);
+			newFiles.delete(fileItem);
+			this.filesChange.emit(newFiles);
+			this.value = newFiles;
 		}
 		this.fileInput.nativeElement.value = "";
-		if (shouldEmit) {
-			this.filesChange.emit(this.files);
-		}
 	}
 
 	public isTemplate(value) {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2531

File Uploader had inconsistent behavior in how Forms events would fire between the drag-and-drop version and the standard version of the component. In Reactive Forms, for example, the `(valueChanges)` event wouldn't fire for the drag-and-drop version even though it would fire for the standard version.

#### Changelog

**Changed**

`valueChanges` API now behaves consistently across the `drop` version and non-drop version of the `ibm-file-uploader` component.