### PR TITLE
fix: Emit close event on Escape

### DIFF
--- a/src/modal/base-modal.service.ts
+++ b/src/modal/base-modal.service.ts
@@ -85,8 +85,8 @@ export class BaseModalService {
 		// Let animation finish before component is removed
 		setTimeout(() => {
 			this.placeholderService.destroyComponent(BaseModalService.modalList[index]);
+			BaseModalService.modalList.splice(index, 1);
 		}, 240);
-		BaseModalService.modalList.splice(index, 1);
 	}
 }
 

--- a/src/modal/base-modal.service.ts
+++ b/src/modal/base-modal.service.ts
@@ -52,7 +52,7 @@ export class BaseModalService {
 				component.instance.open = false;
 			}),
 			// delay closing by an arbitrary amount to allow the animation to finish
-			delay(150)
+			delay(240)
 		).subscribe(() => {
 			this.placeholderService.destroyComponent(component);
 			// filter out our component
@@ -85,7 +85,7 @@ export class BaseModalService {
 		// Let animation finish before component is removed
 		setTimeout(() => {
 			this.placeholderService.destroyComponent(BaseModalService.modalList[index]);
-		}, 300);
+		}, 240);
 		BaseModalService.modalList.splice(index, 1);
 	}
 }

--- a/src/modal/base-modal.service.ts
+++ b/src/modal/base-modal.service.ts
@@ -82,7 +82,10 @@ export class BaseModalService {
 			index = BaseModalService.modalList.length - 1;
 		}
 
-		this.placeholderService.destroyComponent(BaseModalService.modalList[index]);
+		// Let animation finish before component is removed
+		setTimeout(() => {
+			this.placeholderService.destroyComponent(BaseModalService.modalList[index]);
+		}, 300);
 		BaseModalService.modalList.splice(index, 1);
 	}
 }

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -196,8 +196,10 @@ export class Modal implements AfterViewInit, OnChanges, OnDestroy {
 		switch (event.key) {
 			case "Escape": {
 				event.stopImmediatePropagation();  // prevents events being fired for multiple modals if more than 2 open
-				this.modalService.destroy();  // destroy top (latest) modal
+				// Manually close modal
+				this.open = false;
 				this.close.emit();
+				this.modalService.destroy();  // destroy top (latest) modal
 				break;
 			}
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2530

#### Changelog

**Changed**

* Emits a close event before modal is destroyed
* Destroys modal After 300ms (To late animation complete), after destroy function is called for topmost modal.
