### PR TITLE
fix(file-uploader): Fix a11y role 'none'

### DIFF
--- a/src/file-uploader/file-uploader.component.ts
+++ b/src/file-uploader/file-uploader.component.ts
@@ -31,11 +31,11 @@ const noop = () => { };
 					(keyup.enter)="fileInput.click()"
 					(keyup.space)="fileInput.click()"
 					[ngClass]="{'bx--file-browse-btn--disabled': disabled}"
+					role="button"
 					tabindex="0">
 					<div
 						class="bx--file__drop-container"
 						[ngClass]="{'bx--file__drop-container--drag-over': dragOver}"
-						role="button"
 						(click)="fileInput.click()"
 						[attr.for]="fileUploaderId"
 						(dragover)="onDragOver($event)"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2552

There's no need to have the `<label>` tabbable with no `role` and to have the `<div>` element not tabbable but with `role` so I consolidated both attributes onto the `<label>` element. Tested tabbing with the keyboard on the drag and drop area and opening the file dialog. Tested also just clicking with the mouse on the area.

The error is no longer showing in the IBM Equal Access Accessibility Checker:

![image](https://github.com/carbon-design-system/carbon-components-angular/assets/1253469/f1de3ebc-d35a-4e17-add7-be50c7146427)
