### PR TITLE
fix(table-toolbar): Fix a11y violations

### DIFF
--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -50,12 +50,10 @@ import { TableRowSize } from "../table.types";
 		class="bx--table-toolbar"
 		[ngClass]="{'bx--table-toolbar--small' : size === 'sm'}">
 		<div
-			*ngIf="model"
-			class="bx--batch-actions"
-			[ngClass]="{
-				'bx--batch-actions--active': selected
-			}"
-			[attr.aria-label]="actionBarLabel.subject | async">
+			*ngIf="model && selected"
+			class="bx--batch-actions bx--batch-actions--active"
+			[attr.aria-label]="actionBarLabel.subject | async"
+			role="group">
 			<div class="bx--action-list">
 				<ng-content select="ibm-table-toolbar-actions"></ng-content>
 				<button


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2551

This PR fixes a11y violations when the toolbar is not showing and when it's showing. It also changes the toolbar behavior to be completely invisible (as in not in the DOM) when it's not showing which fixes one more violation without changing the functionality in any way.

Before

![image](https://github.com/carbon-design-system/carbon-components-angular/assets/1253469/bcee4433-ace5-4375-ac5b-debd096375a3)

![image](https://github.com/carbon-design-system/carbon-components-angular/assets/1253469/018a2929-c6bc-44d6-a655-305e3d302159)


After

![image](https://github.com/carbon-design-system/carbon-components-angular/assets/1253469/d1ace581-e424-47f5-956e-cd5910bc3121)

![image](https://github.com/carbon-design-system/carbon-components-angular/assets/1253469/46891c85-b38e-4fdb-8f39-33c53fd9945a)
