### PR TITLE
fix(code-snippet): Fix an a11y violation

### DIFF
--- a/src/code-snippet/code-snippet.component.ts
+++ b/src/code-snippet/code-snippet.component.ts
@@ -33,7 +33,7 @@ export enum SnippetType {
 		</ng-container>
 
 		<ng-template #notInline>
-			<div class="bx--snippet-container" [attr.aria-label]="translations.CODE_SNIPPET_TEXT">
+			<div class="bx--snippet-container" [attr.aria-label]="translations.CODE_SNIPPET_TEXT" role="textbox" aria-readonly="true">
 				<ng-container *ngIf="skeleton">
 					<span *ngIf="display === 'single'; else multiSkeleton"></span>
 					<ng-template #multiSkeleton>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2550

This PR adds a `role` and a `aria-readonly` attributes in order to fix the a11y violation. I took those from https://react.carbondesignsystem.com/?path=/story/components-codesnippet--singleline

Before

![image](https://github.com/carbon-design-system/carbon-components-angular/assets/1253469/02348acf-8bec-413b-9637-05f9eddf0a47)


After

![image](https://github.com/carbon-design-system/carbon-components-angular/assets/1253469/0a532349-52e4-4e4d-8af9-13455476054c)
