### PR TITLE
fix(toggle): set the name and value attributes

### DIFF
--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -103,6 +103,16 @@ export class Toggle extends Checkbox {
 	static toggleCount = 0;
 
 	/**
+	 * Variable set the value to input true/false.
+	 */
+	value = false;
+
+	/**
+	 * Variable set the name to input same as Id.
+	 */
+	name = "toggle-" + Toggle.toggleCount;
+
+	/**
 	 * Text that is set on the left side of the toggle.
 	 */
 	@Input()
@@ -193,6 +203,7 @@ export class Toggle extends Checkbox {
 		this.change.emit(event);
 		/* end deprecation */
 
+		this.value = this.checked;
 		this.checkedChange.emit(this.checked);
 		this.propagateChange(this.checked);
 	}

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -67,8 +67,8 @@ export class ToggleChange {
 				'bx--skeleton': skeleton
 			}"
 			[id]="id"
-			[value]="value"
-			[name]="name"
+			[attr.value]="value"
+			[attr.name]="name"
 			[required]="required"
 			[checked]="checked"
 			[disabled]="disabled"

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -103,16 +103,6 @@ export class Toggle extends Checkbox {
 	static toggleCount = 0;
 
 	/**
-	 * Variable set the value to input true/false.
-	 */
-	value = false;
-
-	/**
-	 * Variable set the name to input same as Id.
-	 */
-	name = "toggle-" + Toggle.toggleCount;
-
-	/**
 	 * Text that is set on the left side of the toggle.
 	 */
 	@Input()
@@ -203,7 +193,6 @@ export class Toggle extends Checkbox {
 		this.change.emit(event);
 		/* end deprecation */
 
-		this.value = this.checked;
 		this.checkedChange.emit(this.checked);
 		this.propagateChange(this.checked);
 	}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-angular/issues/2535

This Pr will only add the value of the attribute [value] and [name] to the input element in the toggle.

#### Changelog

**Before**
![image](https://github.com/carbon-design-system/carbon-components-angular/assets/29485284/93b304b7-f16b-4802-98ff-769e5bbd8339)

**After**


![image](https://github.com/carbon-design-system/carbon-components-angular/assets/29485284/a13fc222-a556-4dc4-8806-6cc33e671449)


