### PR TITLE
fix: Bubble click event

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -70,9 +70,9 @@ import { Observable } from "rxjs";
 						<span class="bx--tag__label">{{ pills.length }}</span>
 						<button
 							type="button"
-							(click)="clearSelected()"
+							(click)="clearSelected($event)"
 							(blur)="onBlur()"
-							(keydown.enter)="clearSelected()"
+							(keydown.enter)="clearSelected($event)"
 							class="bx--tag__close-icon"
 							tabindex="0"
 							[title]="clearSelectionsTitle"
@@ -402,7 +402,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	/** Emits the search string from the input */
 	@Output() search = new EventEmitter<string>();
 	/** Emits an event when the clear button is clicked. */
-	@Output() clear = new EventEmitter();
+	@Output() clear = new EventEmitter<Event>();
 	/** ContentChild reference to the instantiated dropdown list */
 	// @ts-ignore
 	@ContentChild(AbstractDropdownView, { static: true }) view: AbstractDropdownView;
@@ -664,7 +664,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 		this.checkForReorder();
 	}
 
-	public clearSelected() {
+	public clearSelected(event) {
 		this.items = this.items.map(item => {
 			if (!item.disabled) {
 				item.selected = false;
@@ -678,7 +678,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 		const selected = this.view.getSelected();
 		this.propagateChangeCallback(selected);
 		this.selected.emit(selected as any);
-		this.clear.emit();
+		this.clear.emit(event);
 	}
 
 	/**
@@ -777,7 +777,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 		event.preventDefault();
 
 		if (this.type === "single") { // don't want to clear selected or close if multi
-			this.clearSelected();
+			this.clearSelected(event);
 			this.closeDropdown();
 		}
 

--- a/src/combobox/combobox.stories.ts
+++ b/src/combobox/combobox.stories.ts
@@ -296,7 +296,7 @@ storiesOf("Components|Combobox", module)
 					(selected)="selected($event)"
 					(submit)="submit($event)"
 					(search)="search($event)"
-					(clear)="clear()">
+					(clear)="clear($event)">
 					<ibm-dropdown-list></ibm-dropdown-list>
 				</ibm-combo-box>
 		`,
@@ -432,7 +432,7 @@ storiesOf("Components|Combobox", module)
 					type="multi"
 					(selected)="selected($event)"
 					(submit)="submit($event)"
-					(clear)="clear()">
+					(clear)="clear($event)">
 					<ibm-dropdown-list></ibm-dropdown-list>
 				</ibm-combo-box>
 			</div>


### PR DESCRIPTION
Bubble click event when pill is clicked. This will allow users to stop propagation in components like flyout & prevent them from being closed.

#### Changelog

**New**
* bubbles event & type of event to user on `clear` emit