### PR TITLE
feat: Allow users to project interactive content

### DIFF
--- a/src/tiles/expandable-tile-above.directive.ts
+++ b/src/tiles/expandable-tile-above.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, HostBinding } from "@angular/core";
+
+@Directive({
+	selector: "[cdsAboveFold], [ibmAboveFold]"
+})
+export class ExpandableTileAboveFoldDirective {
+	@HostBinding("class.cds--tile-content__above-the-fold") aboveFold = true;
+}

--- a/src/tiles/expandable-tile-below.directive.ts
+++ b/src/tiles/expandable-tile-below.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, HostBinding } from "@angular/core";
+
+@Directive({
+	selector: "[cdsBelowFold], [ibmBelowFold]"
+})
+export class ExpandableTileBelowFoldDirective {
+	@HostBinding("class.cds--tile-content__below-the-fold") belowFold = true;
+}

--- a/src/tiles/expandable-tile.component.ts
+++ b/src/tiles/expandable-tile.component.ts
@@ -2,9 +2,10 @@ import {
 	Component,
 	Input,
 	ElementRef,
-	AfterContentInit
+	AfterViewInit,
+	ViewChild
 } from "@angular/core";
-import { I18n, Overridable } from "carbon-components-angular/i18n";
+import { I18n } from "carbon-components-angular/i18n";
 import { merge } from "carbon-components-angular/utils";
 
 export interface ExpandableTileTranslations {
@@ -16,6 +17,7 @@ export interface ExpandableTileTranslations {
 	selector: "cds-expandable-tile, ibm-expandable-tile",
 	template: `
 		<button
+			*ngIf="!interactive"
 			class="cds--tile cds--tile--expandable"
 			[ngClass]="{
 				'cds--tile--is-expanded' : expanded,
@@ -23,32 +25,67 @@ export interface ExpandableTileTranslations {
 			}"
 			[ngStyle]="{'max-height': expandedHeight + 'px'}"
 			type="button"
-			(click)="onClick()">
-			<div class="cds--tile__chevron">
-				<svg *ngIf="!expanded" width="12" height="7" viewBox="0 0 12 7" [attr.title]="expand.subject | async" role="img">
-					<title>{{expand.subject | async}}</title>
-					<path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z"/>
-				</svg>
-				<svg *ngIf="expanded" width="12" height="7" viewBox="0 0 12 7" [attr.title]="collapse.subject | async" role="img">
-					<title>{{collapse.subject | async}}</title>
-					<path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z"/>
-				</svg>
-			</div>
-			<div class="cds--tile-content">
-				<ng-content select=".cds--tile-content__above-the-fold"></ng-content>
-				<ng-content select=".cds--tile-content__below-the-fold"></ng-content>
-			</div>
+			(click)="onClick()"
+			[attr.aria-expanded]="expanded"
+			[attr.title]="(expanded ? collapse.subject : expand.subject) | async">
+				<ng-container *ngTemplateOutlet="expandableTileContent"></ng-container>
 		</button>
+
+		<div
+			*ngIf="interactive"
+			class="cds--tile cds--tile--expandable cds--tile--expandable--interactive"
+			[ngClass]="{
+				'cds--tile--is-expanded' : expanded,
+				'cds--tile--light': theme === 'light'
+			}"
+			[ngStyle]="{'max-height': expandedHeight + 'px'}"
+			[attr.title]="(expanded ? collapse.subject : expand.subject) | async">
+			<ng-container *ngTemplateOutlet="expandableTileContent"></ng-container>
+		</div>
+
+		<ng-template #chevronIcon>
+			<svg cdsIcon="chevron--down" size="16"></svg>
+		</ng-template>
+
+		<ng-template #expandableTileContent>
+			<div #container>
+				<div class="cds--tile-content">
+					<ng-content select="[cdsAboveFold],[ibmAboveFold],.cds--tile-content__above-the-fold"></ng-content>
+				</div>
+				<div *ngIf="!interactive" class="cds--tile__chevron">
+					<ng-container *ngTemplateOutlet="chevronIcon"></ng-container>
+				</div>
+				<button
+					*ngIf="interactive"
+					class="cds--tile__chevron cds--tile__chevron--interactive"
+					type="button"
+					(click)="onClick()"
+					[attr.aria-expanded]="expanded"
+					[attr.aria-label]="(expanded ? collapse.subject : expand.subject) | async">
+					<ng-container *ngTemplateOutlet="chevronIcon"></ng-container>
+				</button>
+				<div class="cds--tile-content">
+					<ng-content select="[cdsBelowFold],[ibmBelowFold],.cds--tile-content__below-the-fold"></ng-content>
+				</div>
+			</div>
+		</ng-template>
 	`
 })
-export class ExpandableTile implements AfterContentInit {
+export class ExpandableTile implements AfterViewInit {
 	/**
 	 * @deprecated since v5 - Use `cdsLayer` directive instead
 	 * Set to `"light"` to apply the light style
 	 */
 	@Input() theme: "light" | "dark" = "dark";
 
+	/**
+	 * Set to `true` to expand by default
+	 */
 	@Input() expanded = false;
+	/**
+	 * Set to `true` to toggle interactive
+	 */
+	@Input() interactive = false;
 	/**
 	 * Expects an object that contains some or all of:
 	 * ```
@@ -65,21 +102,22 @@ export class ExpandableTile implements AfterContentInit {
 		this.collapse.override(valueWithDefaults.COLLAPSE);
 	}
 
+	@ViewChild("container") tileContainer: ElementRef;
+
 	tileMaxHeight = 0;
 	currentExpandedHeight = 0;
-	element = this.elementRef.nativeElement;
 
 	expand = this.i18n.getOverridable("TILES.EXPAND");
 	collapse = this.i18n.getOverridable("TILES.COLLAPSE");
 
-	constructor(protected i18n: I18n, protected elementRef: ElementRef) {}
+	constructor(protected i18n: I18n, protected element: ElementRef) {}
 
-	ngAfterContentInit() {
+	ngAfterViewInit() {
 		this.updateMaxHeight();
 	}
 
 	get expandedHeight() {
-		const tile = this.element.querySelector(".cds--tile");
+		const tile = this.element.nativeElement.querySelector(".cds--tile");
 		const tilePadding
 			= parseInt(getComputedStyle(tile).paddingBottom, 10) + parseInt(getComputedStyle(tile).paddingTop, 10);
 		const expandedHeight = this.tileMaxHeight + tilePadding;
@@ -91,9 +129,9 @@ export class ExpandableTile implements AfterContentInit {
 
 	updateMaxHeight() {
 		if (this.expanded) {
-			this.tileMaxHeight = this.element.querySelector(".cds--tile-content").getBoundingClientRect().height;
+			this.tileMaxHeight = this.tileContainer.nativeElement.getBoundingClientRect().height;
 		} else {
-			this.tileMaxHeight = this.element.querySelector(".cds--tile-content__above-the-fold").getBoundingClientRect().height;
+			this.tileMaxHeight = this.element.nativeElement.querySelector(".cds--tile-content__above-the-fold").getBoundingClientRect().height;
 		}
 	}
 

--- a/src/tiles/expandable-tile.component.ts
+++ b/src/tiles/expandable-tile.component.ts
@@ -79,11 +79,11 @@ export class ExpandableTile implements AfterViewInit {
 	@Input() theme: "light" | "dark" = "dark";
 
 	/**
-	 * Set to `true` to expand by default
+	 * Controls the expanded state
 	 */
 	@Input() expanded = false;
 	/**
-	 * Set to `true` to toggle interactive
+	 * Controls the interactive state
 	 */
 	@Input() interactive = false;
 	/**

--- a/src/tiles/expandable-tile.stories.ts
+++ b/src/tiles/expandable-tile.stories.ts
@@ -1,14 +1,19 @@
 /* tslint:disable variable-name */
 
-import { moduleMetadata, Meta, Story  } from "@storybook/angular";
+import { moduleMetadata, Meta, Story } from "@storybook/angular";
 import { LayerModule } from "../layer";
+import { ButtonModule } from "../button";
 import { TilesModule, ExpandableTile } from "./";
 
 export default {
 	title: "Components/Tiles/Expandable",
 	decorators: [
 		moduleMetadata({
-			imports: [TilesModule, LayerModule]
+			imports: [
+				ButtonModule,
+				LayerModule,
+				TilesModule
+			]
 		})
 	],
 	component: ExpandableTile
@@ -18,39 +23,56 @@ const Template: Story<ExpandableTile> = (args) => ({
 	props: args,
 	template: `
 		<cds-expandable-tile>
-			<span class="cds--tile-content__above-the-fold" style="height: 200px">Above the fold content here</span>
-			<span class="cds--tile-content__below-the-fold" style="height: 400px">Below the fold content here</span>
+			<span cdsAboveFold style="height: 200px">Above the fold content here</span>
+			<span cdsBelowFold style="height: 400px">Below the fold content here</span>
 		</cds-expandable-tile>
 	`
 });
 export const Basic = Template.bind({});
 
+const InteractiveTemplate: Story<ExpandableTile> = (args) => ({
+	props: args,
+	template: `
+		<cds-expandable-tile [interactive]="true">
+			<span cdsAboveFold style="height: 200px">
+				Above the fold content
+				<button ibmButton>Click me!</button>
+			</span>
+			<span cdsBelowFold style="height: 400px">
+				Below the fold content here
+				<button ibmButton>No me!</button>
+			</span>
+		</cds-expandable-tile>
+	`
+});
+export const Interactive = InteractiveTemplate.bind({});
+
 const LayerTemplate: Story<ExpandableTile> = (args) => ({
 	props: args,
 	template: `
 		<cds-expandable-tile>
-			<span class="cds--tile-content__above-the-fold" style="height: 200px">
+			<span cdsAboveFold style="height: 200px">
 				First Layer, above the fold content here
 			</span>
-			<span class="cds--tile-content__below-the-fold" style="height: 400px">
+			<span cdsBelowFold style="height: 400px">
 				First Layer, below the fold content here
 			</span>
 		</cds-expandable-tile>
 		<div cdsLayer>
 			<cds-expandable-tile>
-				<span class="cds--tile-content__above-the-fold" style="height: 200px">
+				<span cdsAboveFold style="height: 200px">
 					Second layer, above the fold content here
 				</span>
-				<span class="cds--tile-content__below-the-fold" style="height: 400px">
+				<span cdsBelowFold style="height: 400px">
 					Second layer, below the fold content here
 				</span>
 			</cds-expandable-tile>
 			<div cdsLayer>
 				<cds-expandable-tile>
-					<span class="cds--tile-content__above-the-fold" style="height: 200px">
+					<span cdsAboveFold style="height: 200px">
 						Third layer, above the fold content here
 					</span>
-					<span class="cds--tile-content__below-the-fold" style="height: 400px">
+					<span cdsBelowFold style="height: 400px">
 						Third layer, below the fold content here
 					</span>
 				</cds-expandable-tile>

--- a/src/tiles/index.ts
+++ b/src/tiles/index.ts
@@ -1,5 +1,7 @@
 export * from "./clickable-tile.component";
 export * from "./expandable-tile.component";
+export * from "./expandable-tile-above.directive";
+export * from "./expandable-tile-below.directive";
 export * from "./selection-tile.component";
 export * from "./tile-group.component";
 export * from "./tile-selection.interface";

--- a/src/tiles/tiles.module.ts
+++ b/src/tiles/tiles.module.ts
@@ -4,15 +4,20 @@ import { CommonModule } from "@angular/common";
 import { Tile } from "./tile.component";
 import { ClickableTile } from "./clickable-tile.component";
 import { ExpandableTile } from "./expandable-tile.component";
+import { ExpandableTileAboveFoldDirective } from "./expandable-tile-above.directive";
+import { ExpandableTileBelowFoldDirective } from "./expandable-tile-below.directive";
 import { SelectionTile } from "./selection-tile.component";
 import { TileGroup } from "./tile-group.component";
 import { I18nModule } from "carbon-components-angular/i18n";
+import { IconModule } from "carbon-components-angular/icon";
 import { LinkModule } from "carbon-components-angular/link";
 
 @NgModule({
 	declarations: [
 		Tile,
 		ClickableTile,
+		ExpandableTileAboveFoldDirective,
+		ExpandableTileBelowFoldDirective,
 		ExpandableTile,
 		SelectionTile,
 		TileGroup
@@ -20,6 +25,8 @@ import { LinkModule } from "carbon-components-angular/link";
 	exports: [
 		Tile,
 		ClickableTile,
+		ExpandableTileAboveFoldDirective,
+		ExpandableTileBelowFoldDirective,
 		ExpandableTile,
 		SelectionTile,
 		TileGroup
@@ -27,6 +34,7 @@ import { LinkModule } from "carbon-components-angular/link";
 	imports: [
 		CommonModule,
 		I18nModule,
+		IconModule,
 		LinkModule
 	]
 })


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2528

#### Changelog

**New**

* Allow users to project interactive content
* Adds a `interactive` input for users to initialize tile in interactive state
* Adds new directives to assign fold classes
