### PR TITLE
fix: Remove document click event on dropdown close

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -857,7 +857,6 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 			// if we're appendToBody the list isn't within the _elementRef,
 			// so we've got to check if our target is possibly in there too.
 			!this.dropdownMenu.nativeElement.contains(event.target)) {
-				console.log(this.elementRef.nativeElement.contains(event.target));
 			this.closeDropdown();
 		}
 	}

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -22,7 +22,7 @@ import {
 	getScrollableParents,
 	hasScrollableParents
 } from "carbon-components-angular/utils";
-import { I18n } from "carbon-components-angular/i18n";
+import { I18n, Overridable } from "carbon-components-angular/i18n";
 import { Observable } from "rxjs";
 
 /**


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2628

#### Changelog

**Changed**

* Remove event listener on body when drop down closes
* Performance improvements
