### PR TITLE
fix: Update value after change event is emitted

### DIFF
--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -62,7 +62,7 @@ export class NumberChange {
 				<input
 					type="number"
 					[id]="id"
-					[attr.value]="value"
+					[value]="value"
 					[attr.min]="min"
 					[attr.max]="max"
 					[attr.step]="step"
@@ -71,7 +71,7 @@ export class NumberChange {
 					[attr.aria-label]="ariaLabel"
 					[attr.data-invalid]="invalid ? invalid : null"
 					[placeholder]="placeholder"
-					(input)="onNumberInputChange($event)"/>
+					(change)="onNumberInputChange($event)"/>
 				<svg
 					*ngIf="!skeleton && !warn && invalid"
 					cdsIcon="warning--filled"

--- a/src/number-input/number.stories.ts
+++ b/src/number-input/number.stories.ts
@@ -23,7 +23,6 @@ const Template: Story<NumberComponent> = (args) => ({
 			[min]="min"
 			[max]="max"
 			[step]="step"
-			[precision]="precision"
 			[invalid]="invalid"
 			[invalidText]="invalidText"
 			[warn]="warn"
@@ -42,7 +41,6 @@ Basic.args = {
 	min: 0,
 	max: 100,
 	step: 1,
-	precision: 0,
 	invalid: false,
 	disabled: false
 };


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2672

#### Changelog

**Changed**

* Updates/writes component `value` when `change` is emitted. This is to make consistent behavior of entering decimal values across Chrome, Firefox & Safari.

**Removed**

* No longer updates value variable on `input` change
