### PR TITLE
fix: Export code snippet type enum

### DIFF
--- a/src/code-snippet/index.ts
+++ b/src/code-snippet/index.ts
@@ -1,2 +1,2 @@
-export { CodeSnippet } from "./code-snippet.component";
+export { CodeSnippet, SnippetType } from "./code-snippet.component";
 export * from "./code-snippet.module";


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2673

#### Changelog

**New**

* Now exporting SnippetType enum with from Code Snippet directory

