### PR TITLE
fix: Add event to document only when popover is open

### DIFF
--- a/src/toggletip/toggletip.stories.ts
+++ b/src/toggletip/toggletip.stories.ts
@@ -80,7 +80,8 @@ const Template: Story<Toggletip> = (args) => ({
 });
 export const Basic = Template.bind({});
 Basic.args = {
-	isOpen: true
+	isOpen: true,
+	align: "bottom"
 };
 Basic.argTypes = {
 	onOpen: {
@@ -99,7 +100,6 @@ Basic.argTypes = {
 			"left",
 			"right"
 		],
-		defaultValue: "bottom",
 		control: "select"
 	}
 };


### PR DESCRIPTION
When there are hundreds of toggletips open, there is a significant delay for opening/closing the toggletip. This PR aims to improve the performance of applications that have such scenario.

#### Changelog

**Changed**

* Add document:click event only when toggletip is open.
* The event is removed when toggletip is closed.