### PR TITLE
fix: make pagination text consist on resize

### DIFF
--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -89,13 +89,13 @@ export interface PaginationTranslations {
 					</svg>
 				</div>
 			</ng-container>
-			<span *ngIf="!pagesUnknown && totalDataLength <= 1" class="cds--pagination__text" [ngStyle]="{'margin-left': showPageInput ? null : 0}">
+			<span *ngIf="!pagesUnknown && totalDataLength <= 1" class="cds--pagination__text cds--pagination__items-count" [ngStyle]="{'margin-left': showPageInput ? null : 0}">
 				{{totalItemText.subject | i18nReplace:{start: startItemIndex, end: endItemIndex, total: totalDataLength } | async}}
 			</span>
-			<span *ngIf="!pagesUnknown && totalDataLength > 1" class="cds--pagination__text" [ngStyle]="{'margin-left': showPageInput ? null : 0}">
+			<span *ngIf="!pagesUnknown && totalDataLength > 1" class="cds--pagination__text cds--pagination__items-count" [ngStyle]="{'margin-left': showPageInput ? null : 0}">
 				{{totalItemsText.subject | i18nReplace:{start: startItemIndex, end: endItemIndex, total: totalDataLength } | async}}
 			</span>
-			<span *ngIf="pagesUnknown" class="cds--pagination__text" [ngStyle]="{'margin-left': showPageInput ? null : 0}">
+			<span *ngIf="pagesUnknown" class="cds--pagination__text cds--pagination__items-count" [ngStyle]="{'margin-left': showPageInput ? null : 0}">
 				{{totalItemsUnknownText.subject | i18nReplace:{start: startItemIndex, end: endItemIndex } | async}}
 			</span>
 		</div>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2664

On resize of window, pagination information (i.e. items per page, total items count and page number) are getting hide due to media query on `cds--pagination__text` class. I add another class `cds--pagination__items-count` for important pagination information. On smaller size of window, require information will remain on screen.

#### Changelog

**New**

* Add `cds--pagination__items-count` css class to important pagination information display tag.

Before:

https://github.com/carbon-design-system/carbon-components-angular/assets/49565062/92ead07c-a560-433b-83b6-734c115ca2b3

After: 

https://github.com/carbon-design-system/carbon-components-angular/assets/49565062/01135090-0fa2-4f84-b29e-e74c91b50c60

