### PR TITLE
fix: stop drag and drop while disable file upload input

### DIFF
--- a/src/file-uploader/file-uploader.component.ts
+++ b/src/file-uploader/file-uploader.component.ts
@@ -231,6 +231,9 @@ export class FileUploader implements ControlValueAccessor {
 	onDragOver(event) {
 		event.stopPropagation();
 		event.preventDefault();
+		if (this.disabled) {
+			return;
+		}
 		this.dragOver = true;
 	}
 
@@ -243,6 +246,9 @@ export class FileUploader implements ControlValueAccessor {
 	onDrop(event) {
 		event.stopPropagation();
 		event.preventDefault();
+		if (this.disabled) {
+			return;
+		}
 
 		const transferredFiles: Array<File> = Array.from(event.dataTransfer.files);
 		const newFiles = new Set<FileItem>(this.files);


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2642

For Drag and drop file uploader component, if `disabled="true"`, we should not allow to drag a file to upload.

#### Changelog

**New**

* if `disabled="true"`, I stop file to upload.

Before: 

https://github.com/carbon-design-system/carbon-components-angular/assets/49565062/9fece2f5-39ae-4c1d-bc0d-ea0958d134ee


After: 

https://github.com/carbon-design-system/carbon-components-angular/assets/49565062/b98af467-a73a-404d-a549-fb264d0a3513
