### PR TITLE
fix: enable screen reader to read file upload desc and error

### DIFF
--- a/src/file-uploader/file-uploader.component.ts
+++ b/src/file-uploader/file-uploader.component.ts
@@ -21,7 +21,7 @@ const noop = () => { };
 	template: `
 		<ng-container *ngIf="!skeleton; else skeletonTemplate">
 			<label [for]="fileUploaderId" class="cds--file--label">{{title}}</label>
-			<p class="cds--label-description">{{description}}</p>
+			<p class="cds--label-description" role="alert">{{description}}</p>
 			<div class="cds--file">
 				<label
 					*ngIf="drop"

--- a/src/file-uploader/file.component.ts
+++ b/src/file-uploader/file.component.ts
@@ -47,7 +47,7 @@ import { FileItem } from "./file-item.interface";
 				[ariaLabel]="translations.CHECKMARK">
 			</svg>
 		</span>
-		<div class="cds--form-requirement" *ngIf="fileItem.invalid">
+		<div class="cds--form-requirement" role="alert" *ngIf="fileItem.invalid">
 			<div class="cds--form-requirement__title">{{fileItem.invalidTitle}}</div>
 			<p class="cds--form-requirement__supplement">{{fileItem.invalidText}}</p>
 		</div>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2286

Adding a role attribute to description and invalid text so screen reader such as JAWS can read them.

https://www.ibm.com/able/requirements/requirements/#4_1_3

This fix is for version 5

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
