### PR TITLE
fix: remove invalid aria-label for panel

### DIFF
--- a/src/ui-shell/panel/panel.component.ts
+++ b/src/ui-shell/panel/panel.component.ts
@@ -23,5 +23,5 @@ export class Panel {
 	 */
 	@Input() expanded = false;
 
-	@Input() ariaLabel = null;
+	@Input() ariaLabel;
 }

--- a/src/ui-shell/panel/panel.component.ts
+++ b/src/ui-shell/panel/panel.component.ts
@@ -9,6 +9,7 @@ import { Component, Input } from "@angular/core";
 	template: `
 		<div
 			class="cds--header-panel"
+			[attr.aria-label]="ariaLabel"
 			[ngClass]="{
 				'cds--header-panel--expanded': expanded
 			}">
@@ -21,4 +22,6 @@ export class Panel {
 	 * Controls the visibility of the panel
 	 */
 	@Input() expanded = false;
+
+	@Input() ariaLabel = null;
 }

--- a/src/ui-shell/panel/panel.component.ts
+++ b/src/ui-shell/panel/panel.component.ts
@@ -9,7 +9,6 @@ import { Component, Input } from "@angular/core";
 	template: `
 		<div
 			class="cds--header-panel"
-			[attr.aria-label]="ariaLabel"
 			[ngClass]="{
 				'cds--header-panel--expanded': expanded
 			}">
@@ -22,6 +21,4 @@ export class Panel {
 	 * Controls the visibility of the panel
 	 */
 	@Input() expanded = false;
-
-	@Input() ariaLabel = "Header panel";
 }


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2519

Aria attributes must be valid for the element and ARIA role to which they are assigned

https://www.ibm.com/able/requirements/requirements/#4_1_2
