### PR TITLE
updated to have a click event emitter in HeaderAction

### DIFF
--- a/src/button/base-icon-button.component.ts
+++ b/src/button/base-icon-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
 
 /**
  * Base button with common input properties for configuring icon button.
@@ -41,4 +41,9 @@ export class BaseIconButton {
 	 * Set delay when tooltip disappears
 	 */
 	@Input() leaveDelayMs = 300;
+
+	/**
+	 * Emit click of a button if necessary
+	 */
+	@Output() click = new EventEmitter<any>();
 }

--- a/src/ui-shell/header/header-action.component.ts
+++ b/src/ui-shell/header/header-action.component.ts
@@ -60,5 +60,6 @@ export class HeaderAction extends BaseIconButton {
 		this.active = !this.active;
 		this.selected.emit(this.active);
 		this.activeChange.emit(this.active);
+		this.click.emit(this.active);
 	}
 }


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2698

Since moving to the base icon button, the click event does not propagate up the chain. This adds the click event as an Output on the BaseIconButton and the emitter within the onClick function in the UIShellModule Header Action Component

#### Changelog

**Changed**

* BaseIconButton to have an Output
* Header Action click feature returned
