### PR TITLE
fix: Hide table header column data when in skeleton state

### DIFF
--- a/src/table/head/table-head-cell.component.ts
+++ b/src/table/head/table-head-cell.component.ts
@@ -68,7 +68,11 @@ import { TableHeaderItem } from "../table-header-item.class";
 		<div
 			class="cds--table-header-label"
 			*ngIf="!skeleton && this.sort.observers.length === 0 || (this.sort.observers.length > 0 && !column.sortable) || !sortable">
-			<span *ngIf="!column.template" [title]="column.data">{{column.data}}</span>
+			<span *ngIf="!column.template" [title]="column.data">
+				<ng-container *ngIf="!skeleton">
+					{{column.data}}
+				</ng-container>
+			</span>
 			<ng-template
 				[ngTemplateOutlet]="column.template" [ngTemplateOutletContext]="{data: column.data}">
 			</ng-template>

--- a/src/table/head/table-head.component.ts
+++ b/src/table/head/table-head.component.ts
@@ -64,7 +64,6 @@ import { TableRowSize } from "../table.types";
 					[skeleton]="skeleton"
 					[id]="model.getId(i)"
 					[column]="column"
-					[skeleton]="skeleton"
 					[filterTitle]="getFilterTitle()"
 					[attr.colspan]="column.colSpan"
 					[attr.rowspan]="column.rowSpan"


### PR DESCRIPTION
Prior to PR, table header column displayed the header text when in skeleton state. This only occurred when selection columns were shown.


#### Changelog

**Changed**

* Hides the table header column when `showSelectionColumn` is false and table is in `skeleton` state