### PR TITLE
Issue #2687- remove ibm prefix from header-action component

### DIFF
--- a/src/ui-shell/header/header-action.component.ts
+++ b/src/ui-shell/header/header-action.component.ts
@@ -11,7 +11,7 @@ import { BaseIconButton } from "carbon-components-angular/button";
  * Contained by `HeaderGlobal`. Generally used to trigger `Panel`s
  */
 @Component({
-	selector: "cds-header-action, ibm-header-action",
+	selector: "cds-header-action, header-action",
 	template: `
 		<cds-icon-button
 			[buttonNgClass]="{


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-angular/issues/2687

This PR remove "ibm" prefix from the selector of "ibm-header-action" component. Now the user can able to directly call this component by <header-action>

#### Changelog

**Changed**

Previously to use header-action" component, we were calling it by <ibm-header-action>.
As part of this PR, We have removed "ibm" as prefix and this component can be directly use by <header-action>.
 According to discussion on Original issue #2687 , To remove the IBM prefix can increase the outreach.


