### PR TITLE
#2724- Fix of close method invokation in ActionableNotification close…

### DIFF
--- a/src/notification/actionable-notification.component.ts
+++ b/src/notification/actionable-notification.component.ts
@@ -1,7 +1,9 @@
 import {
 	Component,
 	Input,
-	HostBinding
+	HostBinding,
+	Output,
+	EventEmitter
 } from "@angular/core";
 
 import { of } from "rxjs";
@@ -81,7 +83,7 @@ export class ActionableNotification extends BaseNotification {
 		}
 		this._notificationObj = Object.assign({}, this.defaultNotificationObj, obj);
 	}
-
+	@Output() close = new EventEmitter();
 	@HostBinding("attr.id") notificationID = `notification-${ActionableNotification.notificationCount++}`;
 	@HostBinding("class.cds--actionable-notification") notificationClass = true;
 	@HostBinding("class.cds--actionable-notification--toast") get toastVariant() { return this.notificationObj.variant === "toast"; }
@@ -102,6 +104,10 @@ export class ActionableNotification extends BaseNotification {
 		variant: "inline" as NotificationVariants,
 		role: "alertdialog"
 	};
+
+	onClose() {
+		this.close.emit();
+	}
 
 	constructor(protected notificationDisplayService: NotificationDisplayService, protected i18n: I18n) {
 		super(notificationDisplayService, i18n);


### PR DESCRIPTION
… button action

Closes https://github.com/carbon-design-system/carbon-components-angular/issues/2724

When the user will click on close button of ActionableNotification , then the function was not invoked which user defined in html file against close method.
After this Fix- The function will be invoked.

#### Changelog

**New**

The close function will be invoked on clicking of close button of ActionableNotification.
