### PR TITLE
fix: readd support for ibm prefixed selectors

### DIFF
--- a/src/contained-list/contained-list-item.component.ts
+++ b/src/contained-list/contained-list-item.component.ts
@@ -17,7 +17,7 @@ import {
 				type="button"
 				[disabled]="disabled"
 				(click)="onClick()">
-				<ng-content select="[ibmContainedListItemButton]"></ng-content>
+				<ng-content select="[cdsContainedListItemButton],[ibmContainedListItemButton]"></ng-content>
 			</button>
 		</ng-container>
 		<ng-container *ngIf="!clickable">

--- a/src/structured-list/structured-list.component.ts
+++ b/src/structured-list/structured-list.component.ts
@@ -63,7 +63,7 @@ import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
 				'cds--structured-list--condensed': condensed,
 				'cds--skeleton': skeleton
 			}">
-			<ng-content select="cds-list-header"></ng-content>
+			<ng-content select="cds-list-header,ibm-list-header"></ng-content>
 			<div class="cds--structured-list-tbody" role="rowgroup">
 				<ng-content></ng-content>
 			</div>

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -68,7 +68,7 @@ import { TableRowSize } from "../table.types";
 				</p>
 			</div>
 			<div class="cds--action-list">
-				<ng-content select="cds-table-toolbar-actions"></ng-content>
+				<ng-content select="cds-table-toolbar-actions,ibm-table-toolbar-actions"></ng-content>
 				<button
 					cdsButton="primary"
 					class="cds--batch-summary__cancel"

--- a/src/ui-shell/header/header.component.ts
+++ b/src/ui-shell/header/header.component.ts
@@ -30,7 +30,7 @@ import { I18n } from "carbon-components-angular/i18n";
 				tabindex="0">
 				{{ i18n.get("UI_SHELL.SKIP_TO") | async }}
 			</a>
-			<ng-content select="cds-hamburger"></ng-content>
+			<ng-content select="cds-hamburger,ibm-hamburger"></ng-content>
 			<ng-template
 				*ngIf="isTemplate(brand)"
 				[ngTemplateOutlet]="brand">

--- a/src/ui-shell/sidenav/sidenav.component.ts
+++ b/src/ui-shell/sidenav/sidenav.component.ts
@@ -16,7 +16,7 @@ import { NavigationItem } from "../header/header-navigation-items.interface";
 	selector: "cds-sidenav, ibm-sidenav",
 	template: `
 		<nav class="cds--side-nav__items" [attr.aria-label]="ariaLabel">
-			<ng-content select="cds-sidenav-header"></ng-content>
+			<ng-content select="cds-sidenav-header,ibm-sidenav-header"></ng-content>
 			<div role="list">
 				<div class="cds--side-nav__header-navigation cds--side-nav__header-divider">
 					<ng-container *ngFor="let navigationItem of navigationItems">


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2687

#### Changelog

**New**

* For contained list, select now accepts `ibm` prefixed selectors

**Changed**

* Readd support for ibm prefixed selectors for shell and table components
