### PR TITLE
fix for issue #2715

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -350,6 +350,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 		if (this.view) {
 			this.view.type = this.type;
 		}
+		this.skeleton ? this.placeholder = "test" : this.placeholder = this.placeholder;
 	}
 
 	/**


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2715

The place holder has been removed if the skeleton state is set to true.

#### Changelog
![Screenshot 2023-12-08 000832](https://github.com/carbon-design-system/carbon-components-angular/assets/131433061/5d868362-03f6-46b7-b925-44a45cefe1d3)

**New**

* Hides the placeholder of the `multi-select dropdown` if the it is in the  `skeleton` state. 

