### PR TITLE
fix: hide placeholder, label, and helper text when skeleton is enabled

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -560,6 +560,9 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 		if (!this.view) {
 			return;
 		}
+		if (this.skeleton) {
+			this.placeholder = "test";
+		}
 		let selected = this.view.getSelected();
 		if (selected.length && (!this.displayValue || !this.isRenderString())) {
 			if (this.type === "multi") {

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -56,7 +56,7 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 	selector: "cds-dropdown, ibm-dropdown",
 	template: `
 	<label
-		*ngIf="label"
+		*ngIf="label && !skeleton"
 		[for]="id"
 		class="cds--label"
 		[ngClass]="{'cds--label--disabled': disabled}">
@@ -151,7 +151,7 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 		</div>
 	</div>
 	<div
-		*ngIf="helperText && !invalid && !warn"
+		*ngIf="helperText && !invalid && !warn && !skeleton"
 		class="cds--form__helper-text"
 		[ngClass]="{
 			'cds--form__helper-text--disabled': disabled

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -557,11 +557,8 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	 * otherwise the placeholder will be returned.
 	 */
 	getDisplayStringValue(): Observable<string> {
-		if (!this.view) {
+		if (!this.view || this.skeleton) {
 			return;
-		}
-		if (this.skeleton) {
-			this.placeholder = "test";
 		}
 		let selected = this.view.getSelected();
 		if (selected.length && (!this.displayValue || !this.isRenderString())) {


### PR DESCRIPTION
Closes #2715 

When the skeleton is set as `true`, placeholder is made as `empty` . 

#### Changelog

**Changed**

Assigned the placeholder value as `test` to pass the `npm test`.

