### PR TITLE
fix: prevent first dropdown item from scrolling out of view on initial arrow down

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -567,7 +567,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 			this.closeDropdown();
 		} else if ((ev.key === "ArrowDown")
 			&& (!this.dropdownMenu || !this.dropdownMenu.nativeElement.contains(ev.target))) {
-			ev.stopPropagation();
+			ev.preventDefault();
 			this.openDropdown();
 			setTimeout(() => { this.view.initFocus(); }, 0);
 		}

--- a/src/dropdown/dropdown.stories.ts
+++ b/src/dropdown/dropdown.stories.ts
@@ -40,6 +40,24 @@ export default {
 			},
 			{
 				content: "four"
+			},
+			{
+				content: "five"
+			},
+			{
+				content: "six"
+			},
+			{
+				content: "seven"
+			},
+			{
+				content: "eight"
+			},
+			{
+				content: "nine"
+			},
+			{
+				content: "ten"
 			}
 		],
 		appendInline: false,

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -519,7 +519,7 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 				}
 			} else if (event.key === "ArrowUp") {
 				if (this.hasPrevElement()) {
-					this.getPrevElement().scrollIntoView();
+					this.getPrevElement().scrollIntoView({  block: "nearest" });
 				} else {
 					this.blurIntent.emit("top");
 				}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2777

#### Changelog

**Changed**

* Prevent dropdown item from scrolling the page when navigating using arrow keys
* Prevent first combobox item from scrolling out of view on initial arrow down