### PR TITLE
feat: add useRouter property to sidenav

### DIFF
--- a/src/ui-shell/sidenav/side-nav.component.spec.ts
+++ b/src/ui-shell/sidenav/side-nav.component.spec.ts
@@ -17,7 +17,7 @@ class FooComponent { }
 
 @Component({
 	template: `
-		<cds-sidenav [allowExpansion]="allowExpansion" [hidden]="hidden">
+		<cds-sidenav [allowExpansion]="allowExpansion" [hidden]="hidden" [useRouter]="useRouter">
 			<cds-sidenav-menu title="Example Title"></cds-sidenav-menu>
 			<cds-sidenav-item
 				[route]="route"
@@ -31,6 +31,7 @@ class SideNavTest {
 	hidden = false;
 	allowExpansion = false;
 	statusPromise = null;
+	useRouter = false;
 	onNavigation(event) {
 		this.statusPromise = event;
 	}
@@ -70,54 +71,119 @@ describe("SideNav", () => {
 		expect(fixture.componentInstance instanceof SideNav).toBe(true);
 	});
 
-	it("should emit the navigation status promise when the link is activated and call onNavigation", async () => {
-		fixture = TestBed.createComponent(SideNavTest);
-		wrapper = fixture.componentInstance;
-		spyOn(wrapper, "onNavigation").and.callThrough();
-		fixture.detectChanges();
-		element = fixture.debugElement.query(By.css(".cds--side-nav__link"));
-		element.nativeElement.click();
-		fixture.detectChanges();
-		expect(wrapper.onNavigation).toHaveBeenCalled();
-		const status = await wrapper.statusPromise;
-		expect(status).toBe(true);
+	describe("when useRouter is false", () => {
+		let fixture;
+
+		beforeEach(() => {
+			fixture = TestBed.createComponent(SideNavTest);
+			fixture.componentInstance.useRouter = false;
+			fixture.detectChanges();
+		});
+
+		it("should emit the navigation status promise when the link is activated and call onNavigation", async () => {
+			wrapper = fixture.componentInstance;
+			spyOn(wrapper, "onNavigation").and.callThrough();
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css(".cds--side-nav__link"));
+			element.nativeElement.click();
+			fixture.detectChanges();
+			expect(wrapper.onNavigation).toHaveBeenCalled();
+			const status = await wrapper.statusPromise;
+			expect(status).toBe(true);
+		});
+
+		it("should expand sidenav-menu on click", () => {
+			wrapper = fixture.componentInstance;
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css(".cds--side-nav__submenu"));
+			element.nativeElement.click();
+			fixture.detectChanges();
+			expect(element.nativeElement.getAttribute("aria-expanded")).toBe("true");
+			expect(element.componentInstance.expanded).toBe(true);
+			element.nativeElement.click();
+			fixture.detectChanges();
+			expect(element.nativeElement.getAttribute("aria-expanded")).toBe("false");
+			expect(element.componentInstance.expanded).toBe(false);
+		});
+
+		it("should set the sidenav-menu title to Example Title", () => {
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css("cds-sidenav-menu"));
+			expect(element.nativeElement.textContent).toEqual("Example Title");
+		});
+
+		it("should toggle expanded on click", () => {
+			wrapper = fixture.componentInstance;
+			wrapper.allowExpansion = true;
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css("cds-sidenav"));
+			let sidenavButton = element.nativeElement.querySelector(
+				".cds--side-nav__toggle",
+			);
+			element.componentInstance.expanded = false;
+			sidenavButton.click();
+			fixture.detectChanges();
+			expect(element.componentInstance.expanded).toBe(true);
+			sidenavButton.click();
+			fixture.detectChanges();
+			expect(element.componentInstance.expanded).toBe(false);
+		});
 	});
 
-	it("should expand sidenav-menu on click", () => {
-		fixture = TestBed.createComponent(SideNavTest);
-		wrapper = fixture.componentInstance;
-		fixture.detectChanges();
-		element = fixture.debugElement.query(By.css(".cds--side-nav__submenu"));
-		element.nativeElement.click();
-		fixture.detectChanges();
-		expect(element.nativeElement.getAttribute("aria-expanded")).toBe("true");
-		expect(element.componentInstance.expanded).toBe(true);
-		element.nativeElement.click();
-		fixture.detectChanges();
-		expect(element.nativeElement.getAttribute("aria-expanded")).toBe("false");
-		expect(element.componentInstance.expanded).toBe(false);
-	});
+	describe("when useRouter is true", () => {
+		let fixture;
 
-	it("should set the sidenav-menu title to Example Title", () => {
-		fixture = TestBed.createComponent(SideNavTest);
-		fixture.detectChanges();
-		element = fixture.debugElement.query(By.css("cds-sidenav-menu"));
-		expect(element.nativeElement.textContent).toEqual("Example Title");
-	});
+		beforeEach(() => {
+			fixture = TestBed.createComponent(SideNavTest);
+			fixture.componentInstance.useRouter = true;
+			fixture.detectChanges();
+		});
 
-	it("should toggle expanded on click", () => {
-		fixture = TestBed.createComponent(SideNavTest);
-		wrapper = fixture.componentInstance;
-		wrapper.allowExpansion = true;
-		fixture.detectChanges();
-		element = fixture.debugElement.query(By.css("cds-sidenav"));
-		let sidenavButton = element.nativeElement.querySelector(".cds--side-nav__toggle");
-		element.componentInstance.expanded = false;
-		sidenavButton.click();
-		fixture.detectChanges();
-		expect(element.componentInstance.expanded).toBe(true);
-		sidenavButton.click();
-		fixture.detectChanges();
-		expect(element.componentInstance.expanded).toBe(false);
+		it("should not emit the navigation status promise when the link is activated and call onNavigation", async () => {
+			wrapper = fixture.componentInstance;
+			spyOn(wrapper, "onNavigation").and.callThrough();
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css(".cds--side-nav__link"));
+			element.nativeElement.click();
+			fixture.detectChanges();
+			expect(wrapper.onNavigation).not.toHaveBeenCalled();
+		});
+
+		it("should expand sidenav-menu on click", () => {
+			wrapper = fixture.componentInstance;
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css(".cds--side-nav__submenu"));
+			element.nativeElement.click();
+			fixture.detectChanges();
+			expect(element.nativeElement.getAttribute("aria-expanded")).toBe("true");
+			expect(element.componentInstance.expanded).toBe(true);
+			element.nativeElement.click();
+			fixture.detectChanges();
+			expect(element.nativeElement.getAttribute("aria-expanded")).toBe("false");
+			expect(element.componentInstance.expanded).toBe(false);
+		});
+
+		it("should set the sidenav-menu title to Example Title", () => {
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css("cds-sidenav-menu"));
+			expect(element.nativeElement.textContent).toEqual("Example Title");
+		});
+
+		it("should toggle expanded on click", () => {
+			wrapper = fixture.componentInstance;
+			wrapper.allowExpansion = true;
+			fixture.detectChanges();
+			element = fixture.debugElement.query(By.css("cds-sidenav"));
+			let sidenavButton = element.nativeElement.querySelector(
+				".cds--side-nav__toggle",
+			);
+			element.componentInstance.expanded = false;
+			sidenavButton.click();
+			fixture.detectChanges();
+			expect(element.componentInstance.expanded).toBe(true);
+			sidenavButton.click();
+			fixture.detectChanges();
+			expect(element.componentInstance.expanded).toBe(false);
+		});
 	});
 });

--- a/src/ui-shell/sidenav/side-nav.component.spec.ts
+++ b/src/ui-shell/sidenav/side-nav.component.spec.ts
@@ -17,10 +17,11 @@ class FooComponent { }
 
 @Component({
 	template: `
-		<cds-sidenav [allowExpansion]="allowExpansion" [hidden]="hidden" [useRouter]="useRouter">
+		<cds-sidenav [allowExpansion]="allowExpansion" [hidden]="hidden">
 			<cds-sidenav-menu title="Example Title"></cds-sidenav-menu>
 			<cds-sidenav-item
 				[route]="route"
+				[useRouter]="useRouter"
 				(navigation)="onNavigation($event)">
 			</cds-sidenav-item>
 		</cds-sidenav>

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -35,8 +35,7 @@ import { Router } from "@angular/router";
 				[routerLinkActive]="'cds--side-nav__item--active'"
 				[ariaCurrentWhenActive]="'page'"
 				[attr.title]="title ? title : null"
-				class="cds--side-nav__link"
-			>
+				class="cds--side-nav__link">
 				<ng-template [ngTemplateOutlet]="sidenavItemContentTpl"></ng-template>
 			</a>
 		</ng-template>

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -32,8 +32,8 @@ import { Router } from "@angular/router";
 		<ng-template #sidenavItemRouterTpl>
 			<a
 				[routerLink]="route"
-				[routerLinkActive]="'cds--side-nav__item--active'"
-				[ariaCurrentWhenActive]="'page'"
+				routerLinkActive="cds--side-nav__item--active"
+				ariaCurrentWhenActive="page"
 				[attr.title]="title ? title : null"
 				class="cds--side-nav__link">
 				<ng-template [ngTemplateOutlet]="sidenavItemContentTpl"></ng-template>

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -124,8 +124,7 @@ export class SideNavItem implements OnChanges {
 
 	protected _href = "#";
 
-	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) {
-	}
+	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) {}
 
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.active) {

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -9,6 +9,7 @@ import {
 } from "@angular/core";
 import { DomSanitizer } from "@angular/platform-browser";
 import { Router } from "@angular/router";
+import { SideNav } from "./sidenav.component";
 
 /**
  * `SideNavItem` can either be a child of `SideNav` or `SideNavMenu`
@@ -16,22 +17,38 @@ import { Router } from "@angular/router";
 @Component({
 	selector: "cds-sidenav-item, ibm-sidenav-item",
 	template: `
-		<a
-			class="cds--side-nav__link"
-			[ngClass]="{
+		<a *ngIf="!sidenav?.useRouter; else sidenavItemRouterTpl"
+		   class="cds--side-nav__link"
+		   [ngClass]="{
 				'cds--side-nav__item--active': active
 			}"
-			[href]="href"
-			[attr.aria-current]="(active ? 'page' : null)"
-			[attr.title]="title ? title : null"
-			(click)="navigate($event)">
+		   [href]="href"
+		   [attr.aria-current]="(active ? 'page' : null)"
+		   [attr.title]="title ? title : null"
+		   (click)="navigate($event)">
+			<ng-template [ngTemplateOutlet]="sidenavItemContentTpl"></ng-template>
+		</a>
+
+		<ng-template #sidenavItemRouterTpl>
+			<a
+				[routerLink]="route"
+				[routerLinkActive]="'cds--side-nav__item--active'"
+				[ariaCurrentWhenActive]="'page'"
+				[attr.title]="title ? title : null"
+				class="cds--side-nav__link"
+			>
+				<ng-template [ngTemplateOutlet]="sidenavItemContentTpl"></ng-template>
+			</a>
+		</ng-template>
+
+		<ng-template #sidenavItemContentTpl>
 			<div *ngIf="!isSubMenu" class="cds--side-nav__icon">
 				<ng-content select="svg, [icon]"></ng-content>
 			</div>
 			<span class="cds--side-nav__link-text">
 				<ng-content></ng-content>
 			</span>
-		</a>
+		</ng-template>
 	`,
 	styles: [`
 		:host {
@@ -102,15 +119,16 @@ export class SideNavItem implements OnChanges {
 
 	protected _href = "#";
 
-	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) {}
+	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router, @Host() protected sidenav: SideNav) {
+	}
 
-	ngOnChanges(changes) {
+	ngOnChanges(changes: SimpleChanges) {
 		if (changes.active) {
 			this.selected.emit(this.active);
 		}
 	}
 
-	navigate(event) {
+	navigate(event: MouseEvent) {
 		if (this.router && this.route) {
 			event.preventDefault();
 			const status = this.router.navigate(this.route, this.routeExtras);

--- a/src/ui-shell/sidenav/sidenav.component.ts
+++ b/src/ui-shell/sidenav/sidenav.component.ts
@@ -25,6 +25,7 @@ import { NavigationItem } from "../header/header-navigation-items.interface";
 							[href]="navigationItem.href"
 							[route]="navigationItem.route"
 							[routeExtras]="navigationItem.routeExtras"
+							[useRouter]="useRouter"
 							[title]="navigationItem.title">
 							{{ navigationItem.content }}
 						</cds-sidenav-item>
@@ -100,6 +101,11 @@ export class SideNav {
 	 * navigation items.
 	 */
 	@Input() navigationItems: NavigationItem[];
+
+	/**
+	 * Use the routerLink attribute on <a> tag for navigation instead of using event handlers
+	 */
+	@Input() useRouter = false;
 
 	constructor(public i18n: I18n) { }
 

--- a/src/ui-shell/sidenav/sidenav.module.ts
+++ b/src/ui-shell/sidenav/sidenav.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { RouterModule } from "@angular/router";
 
 import { I18nModule } from "carbon-components-angular/i18n";
 
@@ -21,7 +22,7 @@ export {
 		SideNavItem,
 		SideNavMenu
 	],
-	imports: [CommonModule, I18nModule],
+	imports: [CommonModule, I18nModule, RouterModule],
 	exports: [
 		SideNav,
 		SideNavItem,

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -1,7 +1,8 @@
 /* tslint:disable variable-name */
 
+import { importProvidersFrom } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { moduleMetadata, Meta } from "@storybook/angular";
+import { moduleMetadata, Meta, applicationConfig } from "@storybook/angular";
 import { SearchModule } from "../search";
 import { IconModule } from "../icon";
 import { ThemeModule } from "../theme";
@@ -16,6 +17,20 @@ import {
 export default {
 	title: "Components/UI Shell",
 	decorators: [
+		applicationConfig({
+			providers: [
+				importProvidersFrom(RouterModule.forRoot([
+					{
+						path: "bar",
+						component: BarComponent
+					},
+					{
+						path: "foo",
+						component: FooComponent
+					}
+				]))
+			]
+		}),
 		moduleMetadata({
 			declarations: [
 				BarComponent,
@@ -27,16 +42,7 @@ export default {
 				UIShellModule,
 				IconModule,
 				SearchModule,
-				RouterModule.forChild([
-					{
-						path: "bar",
-						component: BarComponent
-					},
-					{
-						path: "foo",
-						component: FooComponent
-					}
-				])
+				RouterModule
 			]
 		})
 	],
@@ -302,6 +308,51 @@ const SideNavigationRouterTemplate = (args) => ({
 });
 export const SideNavigationRouter = SideNavigationRouterTemplate.bind({});
 SideNavigationRouter.storyName = "Side Navigation with router";
+
+
+const SideNavigationUseRouterTemplate = (args) => ({
+	props: args,
+	styles: [`
+		::ng-deep .cds--side-nav__item--active {
+			background: var(--cds-background-selected);
+
+			&:before {
+			    position: absolute;
+    			background-color: var(--cds-border-interactive, #0f62fe);
+    			content: "";
+    			inline-size: 3px;
+    			inset-block-end: 0;
+    			inset-block-start: 0;
+    			inset-inline-start: 0;
+    		}
+		}
+	`],
+	template: `
+		<div [cdsTheme]="theme">
+			<cds-sidenav [useRouter]="true">
+				<cds-sidenav-item [route]="['foo']">
+					<svg cdsIcon="fade" size="16"></svg>
+					Link
+				</cds-sidenav-item>
+				<cds-sidenav-item [route]="['bar']">
+					<svg cdsIcon="fade" size="16"></svg>
+					Link
+				</cds-sidenav-item>
+				<cds-sidenav-menu title="Category title">
+					<svg cdsIcon="fade" icon size="16"></svg>
+					<cds-sidenav-item [route]="['foo']">Link</cds-sidenav-item>
+					<cds-sidenav-item [route]="['bar']">Link</cds-sidenav-item>
+					<cds-sidenav-item [route]="['foo']">Link</cds-sidenav-item>
+				</cds-sidenav-menu>
+			</cds-sidenav>
+		</div>
+		<div style="margin-left: 256px">
+			<router-outlet></router-outlet>
+		</div>
+	`
+});
+export const SideNavigationUseRouter = SideNavigationUseRouterTemplate.bind({});
+SideNavigationUseRouter.storyName = "Side Navigation with useRouter";
 
 const SidePanelTemplate = (args) => ({
 	props: args,

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -312,21 +312,6 @@ SideNavigationRouter.storyName = "Side Navigation with router";
 
 const SideNavigationUseRouterTemplate = (args) => ({
 	props: args,
-	styles: [`
-		::ng-deep .cds--side-nav__item--active {
-			background: var(--cds-background-selected);
-
-			&:before {
-			    position: absolute;
-    			background-color: var(--cds-border-interactive, #0f62fe);
-    			content: "";
-    			inline-size: 3px;
-    			inset-block-end: 0;
-    			inset-block-start: 0;
-    			inset-inline-start: 0;
-    		}
-		}
-	`],
 	template: `
 		<div [cdsTheme]="theme">
 			<cds-sidenav>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2811

This MR adds a `useRouter` option to the SideNav component (which is `false` by default). 
When the `input` is `true`, `routerLink` will be used instead.

#### Changelog

**New**

* adds `useRouter` input to `SideNav` 


