### PR TITLE
fix: sidenavItem component useRouter should be false by default

### DIFF
--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -74,7 +74,7 @@ export class SideNavItem implements OnChanges {
 	/**
 	 * Use the routerLink attribute on <a> tag for navigation instead of using event handlers
 	 */
-	@Input() useRouter = true;
+	@Input() useRouter = false;
 
 	@HostBinding("class.cds--side-nav__item") get sideNav() {
 		return !this.isSubMenu;


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2851

fixed default value for `useRouter` in `sidenav-item.component.ts`

#### Changelog


**Changed**

* fixed default value for `useRouter` in `sidenav-item.component.ts`
