### PR TITLE
feat(Tooltip): expose data input to be passed as template outlet context when rendering the tooltip

### DIFF
--- a/src/button/icon-button.stories.ts
+++ b/src/button/icon-button.stories.ts
@@ -41,7 +41,7 @@ export default {
 				"danger--ghost"
 			],
 			control: { type: "select" },
-			name: "cdsButton"
+			name: "kind"
 		},
 		size: {
 			options: ["sm", "md", "lg", "xl", "2xl"],

--- a/src/tooltip/definition-tooptip.component.ts
+++ b/src/tooltip/definition-tooptip.component.ts
@@ -41,7 +41,7 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			role="tooltip">
 			<span class="cds--popover-content cds--definition-tooltip">
 				<ng-container *ngIf="!isTemplate(description)">{{description}}</ng-container>
-				<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description"></ng-template>
+				<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description" [ngTemplateOutletContext]="{ data }"></ng-template>
 				<span *ngIf="autoAlign" class="cds--popover-caret cds--popover--auto-align"></span>
 			</span>
 			<span *ngIf="!autoAlign" class="cds--popover-caret"></span>
@@ -57,6 +57,10 @@ export class TooltipDefinition extends PopoverContainer {
 	 * The string or template content to be exposed by the tooltip.
 	 */
 	@Input() description: string | TemplateRef<any>;
+	/**
+	 * Optional data for templates
+	 */
+	@Input() data = {}
 
 	constructor(
 		protected elementRef: ElementRef,

--- a/src/tooltip/definition-tooptip.component.ts
+++ b/src/tooltip/definition-tooptip.component.ts
@@ -41,7 +41,7 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			role="tooltip">
 			<span class="cds--popover-content cds--definition-tooltip">
 				<ng-container *ngIf="!isTemplate(description)">{{description}}</ng-container>
-				<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description" [ngTemplateOutletContext]="{ data }"></ng-template>
+				<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description" [ngTemplateOutletContext]="{ $implicit: templateContext }"></ng-template>
 				<span *ngIf="autoAlign" class="cds--popover-caret cds--popover--auto-align"></span>
 			</span>
 			<span *ngIf="!autoAlign" class="cds--popover-caret"></span>
@@ -58,9 +58,9 @@ export class TooltipDefinition extends PopoverContainer {
 	 */
 	@Input() description: string | TemplateRef<any>;
 	/**
-	 * Optional data for templates
+	 * Optional data for templates passed as implicit context
 	 */
-	@Input() data = {}
+	@Input() templateContext: any;
 
 	constructor(
 		protected elementRef: ElementRef,

--- a/src/tooltip/tooltip.component.ts
+++ b/src/tooltip/tooltip.component.ts
@@ -39,7 +39,7 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			<ng-container *ngIf="!disabled">
 				<span class="cds--popover-content cds--tooltip-content">
 					<ng-container *ngIf="!isTemplate(description)">{{description}}</ng-container>
-					<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description"></ng-template>
+					<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description" [ngTemplateOutletContext]="{ data }"></ng-template>
 					<span *ngIf="autoAlign" class="cds--popover-caret cds--popover--auto-align"></span>
 				</span>
 				<span *ngIf="!autoAlign" class="cds--popover-caret"></span>
@@ -69,6 +69,10 @@ export class Tooltip extends PopoverContainer implements AfterContentChecked {
 	 * The string or template content to be exposed by the tooltip.
 	 */
 	@Input() description: string | TemplateRef<any>;
+	/**
+	 * Optional data for templates
+	 */
+	@Input() data = {}
 
 	@ViewChild("contentWrapper") wrapper: ElementRef<HTMLSpanElement>;
 

--- a/src/tooltip/tooltip.component.ts
+++ b/src/tooltip/tooltip.component.ts
@@ -39,7 +39,7 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			<ng-container *ngIf="!disabled">
 				<span class="cds--popover-content cds--tooltip-content">
 					<ng-container *ngIf="!isTemplate(description)">{{description}}</ng-container>
-					<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description" [ngTemplateOutletContext]="{ data }"></ng-template>
+					<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description" [ngTemplateOutletContext]="{ $implicit: templateContext }"></ng-template>
 					<span *ngIf="autoAlign" class="cds--popover-caret cds--popover--auto-align"></span>
 				</span>
 				<span *ngIf="!autoAlign" class="cds--popover-caret"></span>
@@ -70,9 +70,9 @@ export class Tooltip extends PopoverContainer implements AfterContentChecked {
 	 */
 	@Input() description: string | TemplateRef<any>;
 	/**
-	 * Optional data for templates
+	 * Optional data for templates passed as implicit context
 	 */
-	@Input() data = {}
+	@Input() templateContext: any
 
 	@ViewChild("contentWrapper") wrapper: ElementRef<HTMLSpanElement>;
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2853

Reintroduce `data` input to be passed as `ngTemplateOutletContext` when `description` is a template

#### Changelog

**New**

* added `data` input to Tooltip and TooltipDesctiption

**Changed**

* fixed IconButton stories that were showing incorrect input label (`cdsButton` instead of `kind`)

