### PR TITLE
fix: set initial date to input

### DIFF
--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -323,6 +323,10 @@ export class DatePicker implements
 	}
 
 	ngAfterViewInit() {
+		this.input.input.nativeElement.value = this._value[0] ?? "";
+		if (this.range) {
+			this.rangeInput.input.nativeElement.value = this._value[1] ?? "";
+		}
 		setTimeout(() => {
 			this.addInputListeners();
 		}, 0);


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2857

Prevent initial date input from being reset

#### Changelog

**Changed**

* Prevent end date being reset to initial date for range date picker when first set via @Input

