### PR TITLE
fix(Tooltip): tooltip will open only if the mouse remains on it and no longer overlap with other tooltips

### DIFF
--- a/src/tooltip/tooltip.component.ts
+++ b/src/tooltip/tooltip.component.ts
@@ -76,6 +76,8 @@ export class Tooltip extends PopoverContainer implements AfterContentChecked {
 
 	@ViewChild("contentWrapper") wrapper: ElementRef<HTMLSpanElement>;
 
+	private timeoutId: any; // it should be number, but setTimeout below is matching the NodeJs type instead of the JS type
+
 	constructor(
 		protected elementRef: ElementRef,
 		protected ngZone: NgZone,
@@ -89,14 +91,20 @@ export class Tooltip extends PopoverContainer implements AfterContentChecked {
 
 	@HostListener("mouseenter", ["$event"])
 	mouseenter(event) {
-		setTimeout(() => {
+		// If a mouseleave is triggered before the tooltip is displayed (before setTimeout of mouseenter completes)
+		// we trigger the mouseleave only avoiding having to unecessary show the tooltip
+		clearTimeout(this.timeoutId);
+		this.timeoutId = setTimeout(() => {
 			this.handleChange(true, event);
 		}, this.enterDelayMs);
 	}
 
 	@HostListener("mouseleave", ["$event"])
 	mouseleave(event) {
-		setTimeout(() => {
+		// If a mouseleave is triggered before the tooltip is displayed (before setTimeout of mouseenter completes)
+		// we trigger the mouseleave only avoiding having to unecessary show the tooltip
+		clearTimeout(this.timeoutId);
+		this.timeoutId = setTimeout(() => {
 			this.handleChange(false, event);
 		}, this.leaveDelayMs);
 	}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2809

Tooltip will now only open if the timeout actually completes, which means only when the mouse is hovering the element without leaving before the tooltip appears

#### Changelog

**Changed**

* resetting the timeouts set on mouseenter and mouseleave before setting new ones to achieve what described above
