### PR TITLE
fix: include ibm telemetry config file in published build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@carbon/icons": "11.14.0",
         "@carbon/utils-position": "1.1.4",
         "@floating-ui/dom": "1.6.3",
-        "@ibm/telemetry-js": "^1.2.1",
+        "@ibm/telemetry-js": "^1.5.0",
         "flatpickr": "4.6.13",
         "tslib": "2.3.0"
       },
@@ -5796,15 +5796,11 @@
       }
     },
     "node_modules/@ibm/telemetry-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.2.1.tgz",
-      "integrity": "sha512-ZNuqoclscha2RC089RBPkiGzv8g+mQfBOnHDJZEGBFrvsXg0B9lfRGFBSLzCuTR5nFDqVFYb6XqMRu36EiHIDA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.5.0.tgz",
+      "integrity": "sha512-RwOohLaWw97vEEwhPnlDJlORuworVOjC2R6WzSVlG7suG08qTMLVRVpnnunUCSQHyxP1Y30V9IF5vsxVrMBOHg==",
       "bin": {
         "ibmtelemetry": "dist/collect.js"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -39155,9 +39151,9 @@
       "dev": true
     },
     "@ibm/telemetry-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.2.1.tgz",
-      "integrity": "sha512-ZNuqoclscha2RC089RBPkiGzv8g+mQfBOnHDJZEGBFrvsXg0B9lfRGFBSLzCuTR5nFDqVFYb6XqMRu36EiHIDA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.5.0.tgz",
+      "integrity": "sha512-RwOohLaWw97vEEwhPnlDJlORuworVOjC2R6WzSVlG7suG08qTMLVRVpnnunUCSQHyxP1Y30V9IF5vsxVrMBOHg=="
     },
     "@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@carbon/icons": "11.14.0",
     "@carbon/utils-position": "1.1.4",
     "@floating-ui/dom": "1.6.3",
-    "@ibm/telemetry-js": "^1.2.1",
+    "@ibm/telemetry-js": "^1.5.0",
     "flatpickr": "4.6.13",
     "tslib": "2.3.0"
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,4 +16,4 @@ gulp buildMeta
 # generate ALL the documentation
 mkdir dist/docs
 npm run build-storybook
-npm run docs:build && mv documentation dist/docs/
+npm run docs:build && mv documentation dist/docs/ && mv telemetry.yml dist/telemetry.yml

--- a/src/ng-package.json
+++ b/src/ng-package.json
@@ -8,8 +8,8 @@
 		"@carbon/utils-position",
 		"@carbon/icon-helpers",
 		"@carbon/icons",
-		"@carbon/telemetry",
-    "@floating-ui/dom",
-    "flatpickr"
+		"@floating-ui/dom",
+		"@ibm/telemetry-js",
+		"flatpickr"
 	]
 }

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:carbon-design-system/carbon-components-angular.git"
   },
   "scripts": {
-    "postinstall": "carbon-telemetry collect --install"
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "license": "Apache-2.0",
   "author": "IBM",
@@ -18,9 +18,9 @@
   "dependencies": {
     "@carbon/icon-helpers": "10.37.0",
     "@carbon/icons": "11.14.0",
-    "@carbon/telemetry": "0.1.0",
     "@carbon/utils-position": "1.1.4",
     "@floating-ui/dom": "1.6.3",
+    "@ibm/telemetry-js": "^1.5.0",
     "flatpickr": "4.6.13",
     "tslib": "2.3.0"
   }


### PR DESCRIPTION
`telemetry.yml` file needs to be included in published package to be able to collect telemetry. This PR modifies the build script to include such file.

#### Changelog

**Changed**

* Upgrade `@ibm/telemetry-js` to version 1.5.0
* Modify build script to copy `telemetry.yml` to dist folder
* Replace `@carbon/telemetry` with `@ibm/telemetry-js` in `ng-package.json`'s `allowedNonPeerDependencies`
* Replace `@carbon/telemetry` with `@ibm/telemetry-js` in `src/package.json`. Update postinstall script.
