### PR TITLE
fix: shift header to the right when sticky header and single select are enabled

### DIFF
--- a/src/table/cell/table-radio.component.ts
+++ b/src/table/cell/table-radio.component.ts
@@ -2,7 +2,8 @@ import {
 	Component,
 	Input,
 	Output,
-	EventEmitter
+	EventEmitter,
+	HostBinding
 } from "@angular/core";
 import { I18n } from "carbon-components-angular/i18n";
 import { TableItem } from "../table-item.class";
@@ -40,6 +41,9 @@ export class TableRadio {
 	get disabled(): boolean {
 		return this.row ? !!(this.row as TableRow).disabled : false;
 	}
+
+	@HostBinding("class.cds--table-column-radio") radioColumn = true;
+	@HostBinding("class.cds--table-column-checkbox") selectableColumn = true;
 
 	/**
 	 * Used to populate the row selection checkbox label with a useful value if set.

--- a/src/table/head/table-head.component.ts
+++ b/src/table/head/table-head.component.ts
@@ -37,7 +37,6 @@ import { TableRowSize } from "../table.types";
 			<th
 				*ngIf="!skeleton && showSelectionColumn && enableSingleSelect"
 				scope="col"
-				style="width: 0;"
 				[id]="model.getId('select')">
 				<!-- add width 0; since the carbon styles don't seem to constrain this headers width -->
 			</th>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2790

#### Changelog

**Changed**

* Applied missing style classes for table radio element and removed inline styling