### PR TITLE
fix(code-snippet): hide copy button when not inline

### DIFF
--- a/src/code-snippet/code-snippet.component.ts
+++ b/src/code-snippet/code-snippet.component.ts
@@ -74,7 +74,9 @@ export enum SnippetType {
 			</div>
 			<div *ngIf="hasLeft" class="cds--snippet__overflow-indicator--left"></div>
 			<div *ngIf="hasRight" class="cds--snippet__overflow-indicator--right"></div>
-			<ng-container *ngTemplateOutlet="buttonTemplate"></ng-container>
+			<ng-container *ngIf="!hideCopyButton;">
+				<ng-container *ngTemplateOutlet="buttonTemplate"></ng-container>
+			</ng-container>
 			<button
 				*ngIf="isExpandable"
 				class="cds--btn cds--btn--ghost cds--btn--sm cds--snippet-btn--expand"


### PR DESCRIPTION
Issue carbon-design-system/carbon-components-angular#2872

Fixes Hide Copy Button when `display` is not inline in the Code Snippet Component

#### Changelog

**Changed**

* Fixes Hide Copy Button when `display` is not inline in the Code Snippet Component


Screenshots:

For the following HTML code below:
```
<cds-code-snippet [display]="snippetType" [hideCopyButton]="true">
                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis convallis convallis tellus id.
                </cds-code-snippet>
```

And the corresponding Typescript snippet:
```
snippetType: SnippetType = SnippetType.multi
```

Before:
![Screenshot 2024-05-05 at 11 41 23 AM](https://github.com/carbon-design-system/carbon-components-angular/assets/14982488/c0f3f495-04a7-4a1c-89fc-bffb742de825)

After:
![Screenshot 2024-05-05 at 11 41 43 AM](https://github.com/carbon-design-system/carbon-components-angular/assets/14982488/3c2230c4-326f-4dae-ac72-886174763b67)
