### PR TITLE
chore: reference correct module in documentation

### DIFF
--- a/src/slider/slider.component.ts
+++ b/src/slider/slider.component.ts
@@ -21,7 +21,7 @@ import { EventService } from "carbon-components-angular/utils";
  * Get started with importing the module:
  *
  * ```typescript
- * import { SkeletonModule } from 'carbon-components-angular';
+ * import { SliderModule } from 'carbon-components-angular';
  * ```
  *
  * The simplest possible slider usage looks something like:


### PR DESCRIPTION
Correct storybook documentation to `SliderModule` instead of `SkeletonModule` for Slider component

#### Changelog

**Changed**
* Change storybook documentation to use SliderModule instead of SkeletonModule

