### PR TITLE
fix: copy inner text or text content of code element

### DIFF
--- a/src/code-snippet/code-snippet.component.ts
+++ b/src/code-snippet/code-snippet.component.ts
@@ -269,7 +269,7 @@ export class CodeSnippet extends BaseIconButton implements OnInit, AfterViewInit
 	onCopyButtonClicked() {
 		if (!this.disabled) {
 			window.navigator.clipboard
-				.writeText(this.code).then(() => {
+				.writeText(this.code.nativeElement.innerText || this.code.nativeElement.textContent).then(() => {
 					this.showFeedback = true;
 					this.animating = true;
 					setTimeout(() => {

--- a/src/code-snippet/code-snippet.stories.ts
+++ b/src/code-snippet/code-snippet.stories.ts
@@ -11,7 +11,7 @@ export default {
 		})
 	],
 	argTypes: {
-		code: {
+		snippet: {
 			control: false
 		},
 		display: {
@@ -42,34 +42,34 @@ export default {
 const Template = (args) => ({
 	props: args,
 	template: `
-		<cds-code-snippet display="single">{{code}}</cds-code-snippet>
+		<cds-code-snippet display="single">{{snippet}}</cds-code-snippet>
 	`
 });
 export const Basic = Template.bind({});
 Basic.args = {
-	code: `import { UIShellModule } from 'carbon-components-angular'; // Single line of code`
+	snippet: `import { UIShellModule } from 'carbon-components-angular'; // Single line of code`
 };
 
 const InlineTemplate = (args) => ({
 	props: args,
 	template: `
-		Here is some <cds-code-snippet display="inline" [theme]="theme">{{code}}</cds-code-snippet> for you.
+		Here is some <cds-code-snippet display="inline" [theme]="theme">{{snippet}}</cds-code-snippet> for you.
 	`
 });
 export const Inline = InlineTemplate.bind({});
 Inline.args = {
-	code: "<inline code>"
+	snippet: "<inline code>"
 };
 
 const MultiTemplate = (args) => ({
 	props: args,
 	template: `
-		<cds-code-snippet display="multi">{{code}}</cds-code-snippet>
+		<cds-code-snippet display="multi">{{snippet}}</cds-code-snippet>
 	`
 });
 export const Multi = MultiTemplate.bind({});
 Multi.args = {
-	code: `{
+	snippet: `{
 		"name": "carbon-components-angular",
 		"version": "0.0.0",
 		"description": "Next generation components",


### PR DESCRIPTION
Issue went unnoticed due to storybook creating code argument in global scope which was accessible by the component.

#### Changelog

**Changed**

* Now text content is correctly copied to clipboard from code element
* **MISC**: Docs now use different variable name than the one used in component to avoid referencing value in global scope.
