### PR TITLE
fix: pass route extras in routerLink

### DIFF
--- a/src/slider/slider.component.ts
+++ b/src/slider/slider.component.ts
@@ -21,7 +21,7 @@ import { EventService } from "carbon-components-angular/utils";
  * Get started with importing the module:
  *
  * ```typescript
- * import { SkeletonModule } from 'carbon-components-angular';
+ * import { SliderModule } from 'carbon-components-angular';
  * ```
  *
  * The simplest possible slider usage looks something like:

--- a/src/ui-shell/sidenav/side-nav.component.spec.ts
+++ b/src/ui-shell/sidenav/side-nav.component.spec.ts
@@ -18,7 +18,7 @@ class FooComponent { }
 @Component({
 	template: `
 		<cds-sidenav [allowExpansion]="allowExpansion" [hidden]="hidden">
-			<cds-sidenav-menu title="Example Title"></cds-sidenav-menu>
+			<cds-sidenav-menu title="Example Title"></cds-sidenav-menu>
 			<cds-sidenav-item
 				[route]="route"
 				[useRouter]="useRouter"
@@ -38,7 +38,7 @@ class SideNavTest {
 	}
 }
 
-describe("SideNav", () => {
+fdescribe("SideNav", () => {
 	let fixture, wrapper, element;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
@@ -67,7 +67,7 @@ describe("SideNav", () => {
 		});
 	});
 
-	it("should work", () => {
+	it("should work", () => {
 		fixture = TestBed.createComponent(SideNav);
 		expect(fixture.componentInstance instanceof SideNav).toBe(true);
 	});
@@ -81,7 +81,7 @@ describe("SideNav", () => {
 			fixture.detectChanges();
 		});
 
-		it("should emit the navigation status promise when the link is activated and call onNavigation", async () => {
+		it("should emit the navigation status promise when the link is activated and call onNavigation", async () => {
 			wrapper = fixture.componentInstance;
 			spyOn(wrapper, "onNavigation").and.callThrough();
 			fixture.detectChanges();
@@ -110,7 +110,7 @@ describe("SideNav", () => {
 		it("should set the sidenav-menu title to Example Title", () => {
 			fixture.detectChanges();
 			element = fixture.debugElement.query(By.css("cds-sidenav-menu"));
-			expect(element.nativeElement.textContent).toEqual("Example Title");
+			expect(element.nativeElement.textContent).toEqual("Example Title");
 		});
 
 		it("should toggle expanded on click", () => {
@@ -140,7 +140,7 @@ describe("SideNav", () => {
 			fixture.detectChanges();
 		});
 
-		it("should not emit the navigation status promise when the link is activated and call onNavigation", async () => {
+		it("should not emit the navigation status promise when the link is activated and call onNavigation", async () => {
 			wrapper = fixture.componentInstance;
 			spyOn(wrapper, "onNavigation").and.callThrough();
 			fixture.detectChanges();
@@ -167,7 +167,7 @@ describe("SideNav", () => {
 		it("should set the sidenav-menu title to Example Title", () => {
 			fixture.detectChanges();
 			element = fixture.debugElement.query(By.css("cds-sidenav-menu"));
-			expect(element.nativeElement.textContent).toEqual("Example Title");
+			expect(element.nativeElement.textContent).toEqual("Example Title");
 		});
 
 		it("should toggle expanded on click", () => {

--- a/src/ui-shell/sidenav/side-nav.component.spec.ts
+++ b/src/ui-shell/sidenav/side-nav.component.spec.ts
@@ -38,7 +38,7 @@ class SideNavTest {
 	}
 }
 
-fdescribe("SideNav", () => {
+describe("SideNav", () => {
 	let fixture, wrapper, element;
 	beforeEach(() => {
 		TestBed.configureTestingModule({

--- a/src/ui-shell/sidenav/side-nav.component.spec.ts
+++ b/src/ui-shell/sidenav/side-nav.component.spec.ts
@@ -140,16 +140,6 @@ fdescribe("SideNav", () => {
 			fixture.detectChanges();
 		});
 
-		it("should not emit the navigation status promise when the link is activated and call onNavigation", async () => {
-			wrapper = fixture.componentInstance;
-			spyOn(wrapper, "onNavigation").and.callThrough();
-			fixture.detectChanges();
-			element = fixture.debugElement.query(By.css(".cds--side-nav__link"));
-			element.nativeElement.click();
-			fixture.detectChanges();
-			expect(wrapper.onNavigation).not.toHaveBeenCalled();
-		});
-
 		it("should expand sidenav-menu on click", () => {
 			wrapper = fixture.componentInstance;
 			fixture.detectChanges();

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -18,14 +18,14 @@ import { Router } from "@angular/router";
 	selector: "cds-sidenav-item, ibm-sidenav-item",
 	template: `
 		<a *ngIf="!useRouter; else sidenavItemRouterTpl"
-		   class="cds--side-nav__link"
-		   [ngClass]="{
+			class="cds--side-nav__link"
+			[ngClass]="{
 				'cds--side-nav__item--active': active
 			}"
-		   [href]="href"
-		   [attr.aria-current]="(active ? 'page' : null)"
-		   [attr.title]="title ? title : null"
-		   (click)="navigate($event)">
+			[href]="href"
+			[attr.aria-current]="(active ? 'page' : null)"
+			[attr.title]="title ? title : null"
+			(click)="navigate($event)">
 			<ng-template [ngTemplateOutlet]="sidenavItemContentTpl"></ng-template>
 		</a>
 
@@ -33,6 +33,7 @@ import { Router } from "@angular/router";
 			<a
 				[routerLink]="route"
 				routerLinkActive="cds--side-nav__item--active"
+				(click)="navigate($event)"
 				ariaCurrentWhenActive="page"
 				[attr.title]="title ? title : null"
 				class="cds--side-nav__link">


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2904

#### Changelog

**Changed**

* Now calling `navigate` function on anchor link click which will pass in routeExtras.
