### PR TITLE
docs: update support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ That's it! Now we can run `npm start` and start building out our application!
   - IBMers should use our #carbon-ng Slack channel
 
 Angular version support matrix:
-| Angular | v3 | v4 | v5 (future release) |
+| Angular | v3 | v4 | v5 |
 | ------- | -- | -- | ------------------- |
 | 6       | ✅ | ❌ | ❌                   |
 | 7       | ✅ | ✅ | ❌                   |
@@ -68,6 +68,7 @@ Angular version support matrix:
 | 14      | ❌ | ✅ | ✅                   |
 | 15      | ❌ | ✅ | ✅                   |
 | 16      | ❌ | ❌ | ✅                   |
+| 17      | ❌ | ❌ | ✅                   |
 
 Carbon Components Angular version support matrix:
 | Carbon Components Angular version | Community support | Active support |


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2906

Updates support matrix in readme to include Angular 17. v5 is no longer marked as future release.

