### PR TITLE
fix: Allow users to pass in templates in tabs to allow onDestroy hook to be called for content

### DIFF
--- a/src/tabs/tab.component.ts
+++ b/src/tabs/tab.component.ts
@@ -63,8 +63,12 @@ import {
 			[ngStyle]="{'display': active ? null : 'none'}"
 			[attr.aria-labelledby]="id + '-header'"
 			aria-live="polite">
-			<ng-content></ng-content>
+			<ng-template *ngIf="isTemplate(tabContent); else projectedContent" [ngTemplateOutlet]="tabContent"></ng-template>
 		</div>
+		<ng-template #projectedContent>
+			<ng-content></ng-content>
+		</ng-template>
+
 	`
 })
 export class Tab implements OnInit {
@@ -111,6 +115,9 @@ export class Tab implements OnInit {
 	@Input() set cacheActive(shouldCache: boolean) {
 		this._cacheActive = shouldCache;
 	}
+
+	@Input() tabContent: TemplateRef<any>;
+
 	/**
 	 * Value 'selected' to be emitted after a new `Tab` is selected.
 	 */
@@ -149,5 +156,9 @@ export class Tab implements OnInit {
 	*/
 	shouldRender() {
 		return this.active || this.cacheActive;
+	}
+
+	public isTemplate(value) {
+		return value instanceof TemplateRef;
 	}
 }

--- a/src/tabs/tab.component.ts
+++ b/src/tabs/tab.component.ts
@@ -63,7 +63,11 @@ import {
 			[ngStyle]="{'display': active ? null : 'none'}"
 			[attr.aria-labelledby]="id + '-header'"
 			aria-live="polite">
-			<ng-template *ngIf="isTemplate(tabContent)" [ngTemplateOutlet]="tabContent" [ngTemplateOutletContext]="{ $implicit: templateContext }"></ng-template>
+			<ng-template
+				*ngIf="isTemplate(tabContent)"
+				[ngTemplateOutlet]="tabContent"
+				[ngTemplateOutletContext]="{ $implicit: templateContext }">
+			</ng-template>
 			<ng-content></ng-content>
 		</div>
 	`

--- a/src/tabs/tab.component.ts
+++ b/src/tabs/tab.component.ts
@@ -63,11 +63,9 @@ import {
 			[ngStyle]="{'display': active ? null : 'none'}"
 			[attr.aria-labelledby]="id + '-header'"
 			aria-live="polite">
-			<ng-template *ngIf="isTemplate(tabContent); else projectedContent" [ngTemplateOutlet]="tabContent"></ng-template>
-		</div>
-		<ng-template #projectedContent>
+			<ng-template *ngIf="isTemplate(tabContent)" [ngTemplateOutlet]="tabContent" [ngTemplateOutletContext]="{ $implicit: templateContext }"></ng-template>
 			<ng-content></ng-content>
-		</ng-template>
+		</div>
 	`
 })
 export class Tab implements OnInit {
@@ -114,14 +112,18 @@ export class Tab implements OnInit {
 	@Input() set cacheActive(shouldCache: boolean) {
 		this._cacheActive = shouldCache;
 	}
-
+	/**
+	 * Allows life cycle hooks to be called on the rendered content
+	 */
 	@Input() tabContent: TemplateRef<any>;
-
+	/**
+	 * Optional data for templates passed as implicit context
+	 */
+	@Input() templateContext: any;
 	/**
 	 * Value 'selected' to be emitted after a new `Tab` is selected.
 	 */
 	@Output() selected: EventEmitter<void> = new EventEmitter<void>();
-
 	/**
 	 * Used to set the id property on the element.
 	 */

--- a/src/tabs/tab.component.ts
+++ b/src/tabs/tab.component.ts
@@ -68,7 +68,6 @@ import {
 		<ng-template #projectedContent>
 			<ng-content></ng-content>
 		</ng-template>
-
 	`
 })
 export class Tab implements OnInit {

--- a/src/tabs/tabs.stories.ts
+++ b/src/tabs/tabs.stories.ts
@@ -27,23 +27,19 @@ const Template = (args) => ({
 			[followFocus]="followFocus"
 			[isNavigation]="isNavigation"
 			[cacheActive]="cacheActive">
-			<cds-tab heading="one" [tabContent]="one"></cds-tab>
-			<cds-tab heading="two" [tabContent]="two"></cds-tab>
+			<cds-tab heading="one">Tab Content 1</cds-tab>
+			<cds-tab heading="two">Tab Content 2</cds-tab>
 			<cds-tab heading="three" [tabContent]="three"></cds-tab>
-			<cds-tab heading="four">Tab Content 4</cds-tab>
+			<cds-tab heading="four" [tabContent]="four"></cds-tab>
 		</cds-tabs>
 
 		<!-- Use templates if you would like to have lifecycle hooks called when cacheActive is false -->
-		<ng-template #one>
-			Tab Content 1
-		</ng-template>
-
-		<ng-template #two>
-			Tab Content 2
-		</ng-template>
-
 		<ng-template #three>
 			Tab Content 3
+		</ng-template>
+
+		<ng-template #four>
+			Tab Content 4
 		</ng-template>
 	`
 });

--- a/src/tabs/tabs.stories.ts
+++ b/src/tabs/tabs.stories.ts
@@ -30,10 +30,10 @@ const Template = (args) => ({
 			<cds-tab heading="one" [tabContent]="one"></cds-tab>
 			<cds-tab heading="two" [tabContent]="two"></cds-tab>
 			<cds-tab heading="three" [tabContent]="three"></cds-tab>
-			<cds-tab heading="three">Tab Content 3</cds-tab>
+			<cds-tab heading="four">Tab Content 4</cds-tab>
 		</cds-tabs>
 
-
+		<!-- Use templates if you would like to have lifecycle hooks called when cacheActive is false -->
 		<ng-template #one>
 			Tab Content 1
 		</ng-template>

--- a/src/tabs/tabs.stories.ts
+++ b/src/tabs/tabs.stories.ts
@@ -27,11 +27,24 @@ const Template = (args) => ({
 			[followFocus]="followFocus"
 			[isNavigation]="isNavigation"
 			[cacheActive]="cacheActive">
-			<cds-tab heading="one">Tab Content 1</cds-tab>
-			<cds-tab heading="two">Tab Content 2</cds-tab>
-			<cds-tab heading="three">Tab Content 3</cds-tab>
+			<cds-tab heading="one" [tabContent]="one"></cds-tab>
+			<cds-tab heading="two" [tabContent]="two"></cds-tab>
+			<cds-tab heading="three" [tabContent]="three"></cds-tab>
 			<cds-tab heading="three">Tab Content 3</cds-tab>
 		</cds-tabs>
+
+
+		<ng-template #one>
+			Tab Content 1
+		</ng-template>
+
+		<ng-template #two>
+			Tab Content 2
+		</ng-template>
+
+		<ng-template #three>
+			Tab Content 3
+		</ng-template>
 	`
 });
 export const Basic = Template.bind({});


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2908

Angular keeps track of projected content even if it is conditionally hidden in component it is passed in. This means the life cycle hooks are only called once instead of every time *ngIf condition is set to true within the projecting component.

#### Changelog

**New**
* Allow users to pass in a template as tab content for tabs
* Users can render templates AND/OR projected content
