### PR TITLE
fix: add new contained size classes

### DIFF
--- a/src/contained-list/contained-list.component.ts
+++ b/src/contained-list/contained-list.component.ts
@@ -28,7 +28,11 @@ import { ContainedListKind, ContainedListSize } from "./contained-list.enums";
 				'cds--contained-list--sm': size === ContainedListSize.Small,
 				'cds--contained-list--md': size === ContainedListSize.Medium,
 				'cds--contained-list--lg': size === ContainedListSize.Large,
-				'cds--contained-list--xl': size === ContainedListSize.ExtraLarge
+				'cds--contained-list--xl': size === ContainedListSize.ExtraLarge,
+				'cds--layout--size-sm': size === ContainedListSize.Small,
+				'cds--layout--size-md': size === ContainedListSize.Medium,
+				'cds--layout--size-lg': size === ContainedListSize.Large,
+				'cds--layout--size-xl': size === ContainedListSize.ExtraLarge
 			}">
 			<div class="cds--contained-list__header">
 				<div [id]="labelId" class="cds--contained-list__label">

--- a/src/contained-list/contained-list.stories.ts
+++ b/src/contained-list/contained-list.stories.ts
@@ -183,7 +183,8 @@ const withActionsTemplate = () => ({
 				<svg ibmIcon="subtract--alt" size="16" class="cds--btn__icon"></svg>
 			</button>
 		</ng-template>
-		<cds-contained-list label="List title">
+
+		<cds-contained-list label="List title" [size]="size">
 			<cds-contained-list-item [action]="action">List item</cds-contained-list-item>
 			<cds-contained-list-item [action]="action">List item</cds-contained-list-item>
 			<cds-contained-list-item [action]="action">List item</cds-contained-list-item>
@@ -195,6 +196,7 @@ export const withActions = withActionsTemplate.bind({});
 
 export const withActionsAndContextData = (args) => {
 	args = {
+		...args,
 		items: [
 			{
 				id: 1,
@@ -228,8 +230,7 @@ export const withActionsAndContextData = (args) => {
 					<svg ibmIcon="add" size="16" class="cds--btn__icon"></svg>
 				</button>
 			</ng-template>
-
-			<cds-contained-list label="List title">
+			<cds-contained-list label="List title" [size]="size">
 				<cds-contained-list-item
 					*ngFor="let item of items"
 					[action]="actionWithClick"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2916

#### Changelog

**Changed**

* Add new contained list size classes
* `cds--contained-list--${size}` are deprecated in favor of using `cds--layout--size-${size}` classes. They will be remove in next major version.
