### PR TITLE
fix(TreeNode): label input not correctly rendered when a TemplateRef is used

### DIFF
--- a/src/treeview/tree-node.component.ts
+++ b/src/treeview/tree-node.component.ts
@@ -51,7 +51,12 @@ import { Node } from "./tree-node.types";
 					</svg>
 				</ng-container>
 				<ng-template *ngIf="isTemplate(icon)" [ngTemplateOutlet]="icon"></ng-template>
-				{{label}}
+				<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
+				<ng-template
+					*ngIf="isTemplate(label)"
+					[ngTemplateOutlet]="label"
+					[ngTemplateOutletContext]="{ $implicit: labelContext }">
+				</ng-template>
 			</div>
 			<div
 				*ngIf="children.length"
@@ -85,7 +90,12 @@ import { Node } from "./tree-node.types";
 						[ngTemplateOutlet]="icon"
 						[ngTemplateOutletContext]="{ $implicit: iconContext }">
 					</ng-template>
-					{{label}}
+					<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
+					<ng-template
+						*ngIf="isTemplate(label)"
+						[ngTemplateOutlet]="label"
+						[ngTemplateOutletContext]="{ $implicit: labelContext }">
+					</ng-template>
 				</span>
 			</div>
 			<div
@@ -114,6 +124,7 @@ export class TreeNodeComponent implements AfterContentChecked, OnInit, OnDestroy
 	@Input() disabled = false;
 	@Input() expanded = false;
 	@Input() label: string | TemplateRef<any>;
+	@Input() labelContext: any;
 	@Input() selected = false;
 	@Input() value;
 	@Input() icon: string | TemplateRef<any>;
@@ -138,6 +149,7 @@ export class TreeNodeComponent implements AfterContentChecked, OnInit, OnDestroy
 		this.disabled = node.disabled ?? this.disabled;
 		this.expanded = node.expanded ?? this.expanded;
 		this.label = node.label ?? this.label;
+		this.labelContext = node.labelContext ?? this.labelContext;
 		this.value = node.value ?? this.value;
 		this.icon = node.icon ?? this.icon;
 		this.selected = node.selected ?? this.selected;

--- a/src/treeview/tree-node.types.ts
+++ b/src/treeview/tree-node.types.ts
@@ -2,7 +2,7 @@ import { TemplateRef } from "@angular/core";
 
 export interface Node {
 	label: string | TemplateRef<any>;
-	labelContext: any;
+	labelContext?: any;
 	value?: any;
 	id?: string;
 	active?: boolean;

--- a/src/treeview/tree-node.types.ts
+++ b/src/treeview/tree-node.types.ts
@@ -2,6 +2,7 @@ import { TemplateRef } from "@angular/core";
 
 export interface Node {
 	label: string | TemplateRef<any>;
+	labelContext: any;
 	value?: any;
 	id?: string;
 	active?: boolean;


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2936

The component was defining the label input as `string | TemplateRef<any>`, but only using it as a plain string, resulting in being rendered as `[object Object]` when a template is used. This PR is fixing this behaviour and it's introducing `labelContext` following the similar pattern for icon and parent TreeView component.

#### Changelog

**New**

* TreeNode `Node` interface now defining `labelContext: any` used when `label` is a `TemplateRef`

**Changed**

* handled the possibility of `label` input being a `TemplateRef` in the html of TreeNode
