### PR TITLE
fix: prevent combobox from being cleared when disabled

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -777,6 +777,10 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	clearInput(event) {
 		event.stopPropagation();
 		event.preventDefault();
+		
+		if (this.disabled) {
+			return;
+		}
 
 		if (this.type === "single") { // don't want to clear selected or close if multi
 			this.clearSelected(event);


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2946

When clicking the clear button, check if the component is disabled before clearing the input.

#### Changelog

**Changed**

* ComboBox: do not clear input when component is disabled
