### PR TITLE
docs: render all svgs after a delay to prevent browser from freezing

### DIFF
--- a/src/icon/stories/many-icons-demo.component.ts
+++ b/src/icon/stories/many-icons-demo.component.ts
@@ -41,6 +41,9 @@ export class ManyIconDemo implements OnInit {
 				iconMap.get(descriptor["name"]).push(descriptor);
 			}
 		}
-		this.groupedIcons = Array.from(iconMap.values());
+		// Render after a delay to prevent page from freezing
+		setTimeout(() => {
+			this.groupedIcons = Array.from(iconMap.values());
+		}, 1000);
 	}
 }


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2938

#### Changelog

**Changed**

* Delay rendering of all svgs by 1 second to prevent storybook from crashing
