### PR TITLE
fix: use hidden label instead of aria label for table checkbox

### DIFF
--- a/src/table/cell/table-checkbox.component.ts
+++ b/src/table/cell/table-checkbox.component.ts
@@ -18,10 +18,11 @@ import { TableRowSize } from "../table.types";
 			*ngIf="!skeleton"
 			inline="true"
 			[name]="name"
-			[ariaLabel]="getLabel() | i18nReplace:getSelectionLabelValue(row) | async"
 			[checked]="selected"
 			[disabled]="disabled"
-			(checkedChange)="selectedChange.emit()">
+			(checkedChange)="selectedChange.emit()"
+			[hideLabel]="true">
+				{{getLabel() | i18nReplace:getSelectionLabelValue(row) | async}}
 		</cds-checkbox>
 	`
 })

--- a/src/table/head/table-head-checkbox.component.ts
+++ b/src/table/head/table-head-checkbox.component.ts
@@ -19,7 +19,8 @@ import { Observable } from "rxjs";
 			[checked]="checked"
 			[indeterminate]="indeterminate"
 			(checkedChange)="change.emit()"
-			[ariaLabel]="getAriaLabel() | async">
+			[hideLabel]="true">
+				{{getAriaLabel() | async}}
 		</cds-checkbox>
 	`,
 	styles: [`


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2950

#### Changelog

**Changed**

* Use hidden label instead of aria label for checkbox (row selection) in table.
