### PR TITLE
fix: deeply clone treeNodes to avoid Angular not detecting changes

### DIFF
--- a/src/treeview/treeview.component.ts
+++ b/src/treeview/treeview.component.ts
@@ -70,7 +70,7 @@ export class TreeViewComponent implements AfterViewInit, OnInit, OnDestroy {
 	 * Passing value will disregard projected content
 	 */
 	@Input() set tree(treeNodes: Node[]) {
-		this._tree = treeNodes.map((node) => Object.assign({}, node));
+		this._tree = treeNodes.map((node) => this.copyNode(node));
 		this.treeViewService.contentProjected = false;
 	}
 
@@ -169,5 +169,13 @@ export class TreeViewComponent implements AfterViewInit, OnInit, OnDestroy {
 
 	public isProjected() {
 		return this.treeViewService.contentProjected;
+	}
+
+	private copyNode(node: Node): Node {
+		const copiedNode = Object.assign({}, node)
+		if (node.children) {
+		  copiedNode.children = node.children.map(child => this.copyNode(child))
+		}
+		return copiedNode
 	}
 }

--- a/src/treeview/treeview.component.ts
+++ b/src/treeview/treeview.component.ts
@@ -172,6 +172,7 @@ export class TreeViewComponent implements AfterViewInit, OnInit, OnDestroy {
 	}
 
 	private copyNode(node: Node): Node {
+		// making a recursive shallow copy to avoid performance issues when deeply cloning templateRefs if defined in the node
 		const copiedNode = Object.assign({}, node)
 		if (node.children) {
 		  copiedNode.children = node.children.map(child => this.copyNode(child))

--- a/src/treeview/treeview.component.ts
+++ b/src/treeview/treeview.component.ts
@@ -173,10 +173,10 @@ export class TreeViewComponent implements AfterViewInit, OnInit, OnDestroy {
 
 	private copyNode(node: Node): Node {
 		// making a recursive shallow copy to avoid performance issues when deeply cloning templateRefs if defined in the node
-		const copiedNode = Object.assign({}, node)
+		const copiedNode = Object.assign({}, node);
 		if (node.children) {
-		  copiedNode.children = node.children.map(child => this.copyNode(child))
+		  copiedNode.children = node.children.map(child => this.copyNode(child));
 		}
-		return copiedNode
+		return copiedNode;
 	}
 }


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2965

Deeply clone treeNodes to avoid Angular not detecting changes. Not using lodash cloneDeep to avoid performance issue if any node contains a templateRef.

#### Changelog

**Changed**

* Treeview now deeply cloning treeNodes received as input
