### PR TITLE
feat: allow users to add a custom gap to each node offset

### DIFF
--- a/src/treeview/tree-node.component.ts
+++ b/src/treeview/tree-node.component.ts
@@ -129,6 +129,7 @@ export class TreeNodeComponent implements AfterContentChecked, OnInit, OnDestroy
 	@Input() value;
 	@Input() icon: string | TemplateRef<any>;
 	@Input() iconContext: any;
+	@Input() gap = 0;
 	@Input() children: Node[] = [];
 
 	/**
@@ -154,6 +155,7 @@ export class TreeNodeComponent implements AfterContentChecked, OnInit, OnDestroy
 		this.icon = node.icon ?? this.icon;
 		this.selected = node.selected ?? this.selected;
 		this.depth = node.depth ?? this.depth;
+		this.gap = node.gap ?? this.gap;
 		this.children = node.children ?? this.children;
 		this.iconContext = node.iconText ?? this.iconContext;
 	}
@@ -232,7 +234,7 @@ export class TreeNodeComponent implements AfterContentChecked, OnInit, OnDestroy
 			return this.depth + 2 + this.depth * 0.5;
 		}
 
-		return this.depth + 2.5;
+		return this.depth + this.gap + 2.5;
 	}
 
 	emitFocusEvent(event) {

--- a/src/treeview/tree-node.types.ts
+++ b/src/treeview/tree-node.types.ts
@@ -11,6 +11,7 @@ export interface Node {
 	selected?: boolean;
 	icon?: string | TemplateRef<any>;
 	iconContext?: any;
+	gap?: number;
 	children?: Node[];
 	[key: string]: any;
 }


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2971

A `gap` (number of px) can be defined to add fixed values to the calculated offset, allowing the freedom to adjust levels alignment.

#### Changelog

**New**

* `gap` is a new input in TreeNode, used to be added to the calculated offset

