### PR TITLE
feat: allow users to expand all table rows

### DIFF
--- a/integration/ng18/package-lock.json
+++ b/integration/ng18/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/router": "^18.0.0",
         "@carbon/icons": "^11.44.1",
         "@carbon/styles": "^1.60.1",
-        "carbon-components-angular": "latest",
+        "carbon-components-angular": "*",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -4891,9 +4891,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -4904,7 +4904,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -6527,37 +6527,37 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -6586,14 +6586,23 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/express/node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -8712,10 +8721,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9966,9 +9978,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -10254,12 +10266,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -10830,9 +10842,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -10974,18 +10986,27 @@
       "dev": true
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-function-length": {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -89,6 +89,7 @@ export default {
 		"CHECKBOX_HEADER": "Select all rows",
 		"CHECKBOX_ROW": "Select {{value}}",
 		"EXPAND_BUTTON": "Expand row",
+		"EXPAND_ALL_BUTTON": "Expand all rows",
 		"SORT_DESCENDING": "Sort rows by this header in descending order",
 		"SORT_ASCENDING": "Sort rows by this header in ascending order",
 		"ROW": "row"

--- a/src/table/head/table-head-expand.component.ts
+++ b/src/table/head/table-head-expand.component.ts
@@ -15,8 +15,7 @@ import { Observable } from "rxjs";
 		<button
 			class="cds--table-expand__button"
 			[attr.aria-label]="getAriaLabel() | async"
-			(click)="change.emit(!allRowsExpanded)"
-		>
+			(click)="expandedChange.emit(!expanded)">
 			<svg cdsIcon="chevron--right" size="16" class="cds--table-expand__svg"></svg>
 		</button>
 	`
@@ -24,12 +23,12 @@ import { Observable } from "rxjs";
 export class TableHeadExpand {
 	@HostBinding("class.cds--table-expand") hostClass = true;
 
-	@Input() allRowsExpanded = false;
+	@Input() expanded = false;
 
-	@Output() change = new EventEmitter<boolean>();
+	@Output() expandedChange = new EventEmitter<boolean>();
 
 	@HostBinding("attr.data-previous-value") get previousValue() {
-		return this.allRowsExpanded ? "collapsed" : null;
+		return this.expanded ? "collapsed" : null;
 	}
 
 	protected _ariaLabel = this.i18n.getOverridable("TABLE.EXPAND_ALL_BUTTON");

--- a/src/table/head/table-head-expand.component.ts
+++ b/src/table/head/table-head-expand.component.ts
@@ -1,15 +1,42 @@
 import {
 	Component,
-	HostBinding
+	EventEmitter,
+	HostBinding,
+	Input,
+	Output
 } from "@angular/core";
+import { I18n } from "carbon-components-angular/i18n";
+import { Observable } from "rxjs";
 
 @Component({
 	// tslint:disable-next-line: component-selector
 	selector: "[cdsTableHeadExpand], [ibmTableHeadExpand]",
 	template: `
-		<ng-content></ng-content>
+		<button
+			class="cds--table-expand__button"
+			[attr.aria-label]="getAriaLabel() | async"
+			(click)="change.emit(!allRowsExpanded)"
+		>
+			<svg cdsIcon="chevron--right" size="16" class="cds--table-expand__svg"></svg>
+		</button>
 	`
 })
 export class TableHeadExpand {
 	@HostBinding("class.cds--table-expand") hostClass = true;
+
+	@Input() allRowsExpanded = false;
+
+	@Output() change = new EventEmitter<boolean>();
+
+	@HostBinding("attr.data-previous-value") get previousValue() {
+		return this.allRowsExpanded ? "collapsed" : null;
+	}
+
+	protected _ariaLabel = this.i18n.getOverridable("TABLE.EXPAND_ALL_BUTTON");
+
+	constructor(protected i18n: I18n) { }
+
+	getAriaLabel(): Observable<string> {
+		return this._ariaLabel.subject;
+	}
 }

--- a/src/table/head/table-head-expand.component.ts
+++ b/src/table/head/table-head-expand.component.ts
@@ -13,15 +13,21 @@ import { Observable } from "rxjs";
 	selector: "[cdsTableHeadExpand], [ibmTableHeadExpand]",
 	template: `
 		<button
+			*ngIf="showExpandAllToggle"
 			class="cds--table-expand__button"
 			[attr.aria-label]="getAriaLabel() | async"
 			(click)="expandedChange.emit(!expanded)">
 			<svg cdsIcon="chevron--right" size="16" class="cds--table-expand__svg"></svg>
 		</button>
+		<ng-container *ngIf="!showExpandAllToggle">
+			<ng-content></ng-content>
+		</ng-container>
 	`
 })
 export class TableHeadExpand {
 	@HostBinding("class.cds--table-expand") hostClass = true;
+
+	@Input() showExpandAllToggle = false;
 
 	@Input() expanded = false;
 

--- a/src/table/head/table-head.component.ts
+++ b/src/table/head/table-head.component.ts
@@ -32,7 +32,9 @@ import { TableRowSize } from "../table.types";
 				*ngIf="model.hasExpandableRows()"
 				scope="col"
 				[ngClass]="{'cds--table-expand-v2': stickyHeader}"
-				[id]="model.getId('expand')">
+				[id]="model.getId('expand')"
+				[allRowsExpanded]="model.expandableRowsCount() === model.expandedRowsCount()"
+				(change)="onExpandAllRowsChange($event)">
 			</th>
 			<th
 				*ngIf="!skeleton && showSelectionColumn && enableSingleSelect"
@@ -160,6 +162,18 @@ export class TableHead implements AfterViewInit {
 	 * @param model
 	 */
 	@Output() deselectAll = new EventEmitter<TableModel>();
+	/**
+	 * Emits if all rows are expanded.
+	 *
+	 * @param model
+	 */
+	@Output() expandAllRows = new EventEmitter<TableModel>();
+	/**
+	 * Emits if all rows are collapsed.
+	 *
+	 * @param model
+	 */
+	@Output() collapseAllRows = new EventEmitter<TableModel>();
 
 	public scrollbarWidth = 0;
 
@@ -181,6 +195,14 @@ export class TableHead implements AfterViewInit {
 			this.selectAll.emit(this.model);
 		} else {
 			this.deselectAll.emit(this.model);
+		}
+	}
+
+	onExpandAllRowsChange(expand: boolean) {
+		if (expand) {
+			this.expandAllRows.emit(this.model);
+		} else {
+			this.collapseAllRows.emit(this.model);
 		}
 	}
 

--- a/src/table/head/table-head.component.ts
+++ b/src/table/head/table-head.component.ts
@@ -33,8 +33,8 @@ import { TableRowSize } from "../table.types";
 				scope="col"
 				[ngClass]="{'cds--table-expand-v2': stickyHeader}"
 				[id]="model.getId('expand')"
-				[allRowsExpanded]="model.expandableRowsCount() === model.expandedRowsCount()"
-				(change)="onExpandAllRowsChange($event)">
+				[expanded]="model.expandableRowsCount() === model.expandedRowsCount()"
+				(expandedChange)="onExpandAllRowsChange($event)">
 			</th>
 			<th
 				*ngIf="!skeleton && showSelectionColumn && enableSingleSelect"

--- a/src/table/head/table-head.component.ts
+++ b/src/table/head/table-head.component.ts
@@ -31,6 +31,7 @@ import { TableRowSize } from "../table.types";
 				cdsTableHeadExpand
 				*ngIf="model.hasExpandableRows()"
 				scope="col"
+				[showExpandAllToggle]="showExpandAllToggle"
 				[ngClass]="{'cds--table-expand-v2': stickyHeader}"
 				[id]="model.getId('expand')"
 				[expanded]="model.expandableRowsCount() === model.expandedRowsCount()"
@@ -103,6 +104,8 @@ export class TableHead implements AfterViewInit {
 	@Input() skeleton = false;
 
 	@Input() stickyHeader = false;
+
+	@Input() showExpandAllToggle = false;
 
 	/**
 	 * Setting sortable to false will disable all headers including headers which are sortable. Is is

--- a/src/table/stories/app-expansion-table.component.ts
+++ b/src/table/stories/app-expansion-table.component.ts
@@ -47,6 +47,12 @@ class CustomHeaderItem extends TableHeaderItem {
 			(rowClick)="onRowClick($event)"
 			[isDataGrid]="isDataGrid">
 		</cds-table>
+
+		<br>
+
+		<button cdsButton="primary" size="sm" (click)="model.expandAllRows(true)">Expand all rows</button>
+
+		<button cdsButton="secondary" size="sm" (click)="model.expandAllRows(false)">Collapse all rows</button>
 	`
 })
 export class ExpansionTableStory implements AfterViewInit {

--- a/src/table/stories/app-expansion-table.component.ts
+++ b/src/table/stories/app-expansion-table.component.ts
@@ -45,7 +45,8 @@ class CustomHeaderItem extends TableHeaderItem {
 			[striped]="striped"
 			(sort)="customSort($event)"
 			(rowClick)="onRowClick($event)"
-			[isDataGrid]="isDataGrid">
+			[isDataGrid]="isDataGrid"
+			[showExpandAllToggle]="showExpandAllToggle">
 		</cds-table>
 
 		<br>
@@ -64,6 +65,7 @@ export class ExpansionTableStory implements AfterViewInit {
 	@Input() sortable = true;
 	@Input() stickyHeader = false;
 	@Input() skeleton = false;
+	@Input() showExpandAllToggle = false;
 
 	@ViewChild("customHeaderTemplate")
 	protected customHeaderTemplate: TemplateRef<any>;

--- a/src/table/table-model.class.spec.ts
+++ b/src/table/table-model.class.spec.ts
@@ -760,4 +760,34 @@ describe("Table", () => {
 		expect(tableModel.header[1].data).toEqual("h2");
 		expect(tableModel.header[2].data).toEqual("h3");
 	});
+
+	it("should expand and collapse all rows", () => {
+		let tableModel  = new TableModel();
+
+		spyOn(tableModel.rowsExpandedAllChange, 'emit');
+		spyOn(tableModel.rowsCollapsedAllChange, 'emit');
+
+		tableModel.header = [
+			new TableHeaderItem({data: "h1"}), new TableHeaderItem({data: "h2"})
+		];
+		tableModel.data = [
+			[new TableItem({data: "A", expandedData: "EX1"}), new TableItem({data: "B"})],
+			[new TableItem({data: "C"}), new TableItem({data: "D"})],
+			[new TableItem({data: "E", expandedData: "EX2"}), new TableItem({data: "F"})],
+			[new TableItem({data: "G"}), new TableItem({data: "H"})],
+		];
+		
+		expect(tableModel.expandableRowsCount()).toBe(2);
+		expect(tableModel.expandedRowsCount()).toBe(0);
+
+		tableModel.expandAllRows(true);
+		expect(tableModel.rowsExpandedAllChange.emit).toHaveBeenCalledWith();
+		expect(tableModel.expandedRowsCount()).toBe(2);
+		expect(tableModel.rowsExpanded).toEqual([true, false, true, false])
+
+		tableModel.expandAllRows(false);
+		expect(tableModel.rowsCollapsedAllChange.emit).toHaveBeenCalledWith();
+		expect(tableModel.expandedRowsCount()).toBe(0);
+		expect(tableModel.rowsExpanded).toEqual([false, false, false, false])
+	});
 });

--- a/src/table/table-model.class.spec.ts
+++ b/src/table/table-model.class.spec.ts
@@ -764,8 +764,8 @@ describe("Table", () => {
 	it("should expand and collapse all rows", () => {
 		let tableModel  = new TableModel();
 
-		spyOn(tableModel.rowsExpandedAllChange, 'emit');
-		spyOn(tableModel.rowsCollapsedAllChange, 'emit');
+		spyOn(tableModel.rowsExpandedAllChange, "emit");
+		spyOn(tableModel.rowsCollapsedAllChange, "emit");
 
 		tableModel.header = [
 			new TableHeaderItem({data: "h1"}), new TableHeaderItem({data: "h2"})
@@ -774,20 +774,20 @@ describe("Table", () => {
 			[new TableItem({data: "A", expandedData: "EX1"}), new TableItem({data: "B"})],
 			[new TableItem({data: "C"}), new TableItem({data: "D"})],
 			[new TableItem({data: "E", expandedData: "EX2"}), new TableItem({data: "F"})],
-			[new TableItem({data: "G"}), new TableItem({data: "H"})],
+			[new TableItem({data: "G"}), new TableItem({data: "H"})]
 		];
-		
+
 		expect(tableModel.expandableRowsCount()).toBe(2);
 		expect(tableModel.expandedRowsCount()).toBe(0);
 
 		tableModel.expandAllRows(true);
 		expect(tableModel.rowsExpandedAllChange.emit).toHaveBeenCalledWith();
 		expect(tableModel.expandedRowsCount()).toBe(2);
-		expect(tableModel.rowsExpanded).toEqual([true, false, true, false])
+		expect(tableModel.rowsExpanded).toEqual([true, false, true, false]);
 
 		tableModel.expandAllRows(false);
 		expect(tableModel.rowsCollapsedAllChange.emit).toHaveBeenCalledWith();
 		expect(tableModel.expandedRowsCount()).toBe(0);
-		expect(tableModel.rowsExpanded).toEqual([false, false, false, false])
+		expect(tableModel.rowsExpanded).toEqual([false, false, false, false]);
 	});
 });

--- a/src/table/table-model.class.ts
+++ b/src/table/table-model.class.ts
@@ -69,6 +69,8 @@ export class TableModel implements PaginationModel {
 	dataChange = new EventEmitter();
 	rowsSelectedChange = new EventEmitter<number>();
 	rowsExpandedChange = new EventEmitter<number>();
+	rowsExpandedAllChange = new EventEmitter();
+	rowsCollapsedAllChange = new EventEmitter();
 	/**
 	 * Gets emitted when `selectAll` is called. Emits false if all rows are deselected and true if
 	 * all rows are selected.
@@ -413,6 +415,18 @@ export class TableModel implements PaginationModel {
 		return this.data.some(data => data.some(d => d && d.expandedData)); // checking for some in 2D array
 	}
 
+	/**
+	 * Number of rows that can be expanded.
+	 * 
+	 * @returns number
+	 */
+	expandableRowsCount() {
+		return this.data.reduce((counter, _, index) => {
+			counter = (this.isRowExpandable(index)) ? counter + 1 : counter;
+			return counter;
+		}, 0);
+	}
+
 	isRowExpandable(index: number) {
 		return this.data[index].some(d => d && d.expandedData);
 	}
@@ -703,6 +717,27 @@ export class TableModel implements PaginationModel {
 	expandRow(index: number, value = true) {
 		this.rowsExpanded[index] = value;
 		this.rowsExpandedChange.emit(index);
+	}
+
+	/**
+	 * Expands / collapses all rows
+	 * 
+	 * @param value expanded state of the rows. `true` is expanded and `false` is collapsed
+	 */
+	expandAllRows(value = true) {
+		if (this.data.length > 0) {
+			for (let i = 0; i < this.data.length; i++) {
+				if (this.isRowExpandable(i)) {
+					this.rowsExpanded[i] = value;
+				}
+			}
+
+			if (value) {
+				this.rowsExpandedAllChange.emit();
+			} else {
+				this.rowsCollapsedAllChange.emit();
+			}
+		}
 	}
 
 	/**

--- a/src/table/table-model.class.ts
+++ b/src/table/table-model.class.ts
@@ -417,7 +417,7 @@ export class TableModel implements PaginationModel {
 
 	/**
 	 * Number of rows that can be expanded.
-	 * 
+	 *
 	 * @returns number
 	 */
 	expandableRowsCount() {
@@ -721,7 +721,7 @@ export class TableModel implements PaginationModel {
 
 	/**
 	 * Expands / collapses all rows
-	 * 
+	 *
 	 * @param value expanded state of the rows. `true` is expanded and `false` is collapsed
 	 */
 	expandAllRows(value = true) {

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -197,6 +197,7 @@ import { TableRowSize } from "./table.types";
 			[selectAllCheckboxSomeSelected]="selectAllCheckboxSomeSelected"
 			[showSelectionColumn]="showSelectionColumn"
 			[enableSingleSelect]="enableSingleSelect"
+			[showExpandAllToggle]="showExpandAllToggle"
 			[skeleton]="skeleton"
 			[sortAscendingLabel]="sortAscendingLabel"
 			[sortDescendingLabel]="sortDescendingLabel"
@@ -385,6 +386,11 @@ export class Table implements OnInit, AfterViewInit, OnDestroy {
 	@Input() sortable = true;
 
 	@Input() noBorder = true;
+
+	/**
+	 * Set to `true` to show expansion toggle when table consists of row expansions
+	 */
+	@Input() showExpandAllToggle = false;
 
 	get isDataGrid(): boolean {
 		return this._isDataGrid;

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -187,6 +187,8 @@ import { TableRowSize } from "./table.types";
 			[sortable]="sortable"
 			(deselectAll)="onDeselectAll()"
 			(selectAll)="onSelectAll()"
+			(expandAllRows)="model.expandAllRows(true)"
+			(collapseAllRows)="model.expandAllRows(false)"
 			(sort)="doSort($event)"
 			[checkboxHeaderLabel]="getCheckboxHeaderLabel()"
 			[filterTitle]="getFilterTitle()"

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -482,7 +482,8 @@ const ExpansionTemplate = (args) => ({
 				[stickyHeader]="stickyHeader"
 				[skeleton]="skeleton"
 				[striped]="striped"
-				[isDataGrid]="isDataGrid">
+				[isDataGrid]="isDataGrid"
+				[showExpandAllToggle]="showExpandAllToggle">
 			</app-expansion-table>
 		</cds-table-container>
 	`
@@ -491,7 +492,8 @@ export const WithExpansion = ExpansionTemplate.bind({});
 WithExpansion.args = {
 	...getProps({
 		description: "With expansion"
-	}, "args")
+	}, "args"),
+	showExpandAllToggle: false
 };
 
 const DyanmicContentTemplate = (args) => ({


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#2928

This PR adds a capability to expand / collapse all rows in table.
It can be done by clicking on the icon in the table header or by calling a method on `TableModel`.

<img width="867" alt="image" src="https://github.com/user-attachments/assets/320bdeeb-b6b1-45e4-aec1-a51bb7c8267b">
