### PR TITLE
fix: import utility functions from lodash-es

### DIFF
--- a/src/checkbox/checkbox-exported-tests.ts
+++ b/src/checkbox/checkbox-exported-tests.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import merge from "lodash/merge";
+import merge from "lodash-es/merge";
 import ComponentTests from "../exported-tests/component-tests";
 
 const defaults = {

--- a/src/ui-shell/sidenav/routerlink-extended.directive.ts
+++ b/src/ui-shell/sidenav/routerlink-extended.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, Input, OnChanges, SimpleChanges } from "@angular/core";
 import { NavigationExtras, RouterLinkWithHref } from "@angular/router";
-import keys from "lodash/keys";
+import keys from "lodash-es/keys";
 
 @Directive({
 	// tslint:disable-next-line


### PR DESCRIPTION
* Correct utility function import from `lodash` to `lodash-es`