### PR TITLE
chore(telemetry): update endpoint and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,8 @@ Read our code of conduct [here](./.github/CODE_OF_CONDUCT.md)
 
 ## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
 
-This package uses IBM Telemetry to collect metrics data. By installing this
-package as a dependency you are agreeing to telemetry collection. To opt out,
-see
+This package uses IBM Telemetry to collect de-identified and anonymized metrics data. By installing
+this package as a dependency you are agreeing to telemetry collection. To opt out, see
 [Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
 For more information on the data being collected, please see the
 [IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/telemetry.yml
+++ b/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: dc98c0cb-616b-4fe4-9699-2ec03578aae6
-endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/telemetry
 collect:
   npm:
     dependencies: null


### PR DESCRIPTION
This PR updates the endpoint within each package's `telemetry.yml` file with the new stable endpoint for the collector. Also, this updates the wording used in the telemetry notice under each README.

#### Changelog

- `telemetry.yml` endpoint to new stable endpoint
- updated wording under telemetry notice in each README
