### PR TITLE
chore(ibm-common): removed non-compliant GA tag, onboarded to ibm-common

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -25,17 +25,33 @@
 	document.title = "Carbon Components Angular";
 </script>
 
-<!-- Google Analytics v4 setup -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-G070S732G6"></script>
-<script>
-	window.dataLayer = window.dataLayer || [];
-	function gtag() { dataLayer.push(arguments); }
-	gtag('js', new Date());
-
-	gtag('config', 'G-G070S732G6', {
-		send_page_view: false
-	});
+<!-- Tealium/GA Set up -->
+<script type="text/javascript">
+	window._ibmAnalytics = {
+		settings: {
+			name: 'CarbonAngularStorybook',
+			isSpa: true,
+			tealiumProfileName: 'ibm-web-app',
+		},
+		onLoad: [['ibmStats.pageview', []]],
+	};
+	digitalData = {
+		page: {
+			pageInfo: {
+				ibm: {
+					siteId: 'IBM_' + _ibmAnalytics.settings.name,
+				},
+			},
+			category: {
+				primaryCategory: 'PC100',
+			},
+		},
+	};
 </script>
+<script
+	src="//1.www.s81c.com/common/stats/ibm-common.js"
+	type="text/javascript"
+	async="async"></script>
 
 <style>
 	footer {

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -51,7 +51,8 @@
 <script
 	src="//1.www.s81c.com/common/stats/ibm-common.js"
 	type="text/javascript"
-	async="async"></script>
+	async="async">
+</script>
 
 <style>
 	footer {


### PR DESCRIPTION
The Angular storybook was using a non-compliant GA tag, which is removed in this PR. I have added onboarding to ibm-common.js, which is the approved tag to add for IBM owned web properties.

#### Changelog

**Changed**

* Added `ibm-common.js` and DDO object to manager head for storybook

**Removed**

* non-compliant GA tag
