### PR TITLE
fix(telemetry): updating endpoint

### DIFF
--- a/telemetry.yml
+++ b/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: dc98c0cb-616b-4fe4-9699-2ec03578aae6
-endpoint: https://www-api.ibm.com/ibm-telemetry/v1/telemetry
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
   npm:
     dependencies: null


### PR DESCRIPTION
The PR opened a few days ago updating the endpoint URL had the wrong one -- this PR fixes that.

**Changed**

* Changed `https://www-api.ibm.com/ibm-telemetry/v1/telemetry` to `https://www-api.ibm.com/ibm-telemetry/v1/metrics`
