### PR TITLE
fix: Ensure same size for prev and next button for pagination nav component

### DIFF
--- a/src/pagination/pagination-nav/pagination-nav.component.ts
+++ b/src/pagination/pagination-nav/pagination-nav.component.ts
@@ -95,6 +95,7 @@ export interface PaginationNavTranslations {
 				<li class="cds--pagination-nav__list-item">
 					<cds-icon-button
 						kind="ghost"
+						size="md"
 						(click)="jumpToNext()"
 						[disabled]="rightArrowDisabled"
 						[description]="nextItemText.subject | async">


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#

Ensure same size for prev and next button for pagination nav component

### Before
<img width="548" alt="Scherm­afbeelding 2024-10-23 om 11 11 41" src="https://github.com/user-attachments/assets/87c12cd7-24fa-476b-826d-a322a828eff1">
<img width="426" alt="Scherm­afbeelding 2024-10-23 om 11 11 45" src="https://github.com/user-attachments/assets/5ae0a26d-6dea-47c1-a785-95582166caec">

### After
<img width="542" alt="Scherm­afbeelding 2024-10-23 om 11 15 19" src="https://github.com/user-attachments/assets/eb93c93f-5adc-417c-9300-4ae9be78855b">

#### Changelog

**Changed**

* added missing size property with value `md` to the next button

