### PR TITLE
feat: allow specifying a size for the pagination nav component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@angular/platform-browser-dynamic": "14.3.0",
         "@angular/router": "14.3.0",
         "@babel/core": "7.9.6",
-        "@carbon/styles": "1.56.0",
+        "@carbon/styles": "1.67.0",
         "@carbon/themes": "11.24.0",
         "@commitlint/cli": "17.0.3",
         "@commitlint/config-conventional": "17.0.3",
@@ -3809,34 +3809,34 @@
       }
     },
     "node_modules/@carbon/colors": {
-      "version": "11.21.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.21.0.tgz",
-      "integrity": "sha512-qvVcguNL+rOfdOv7NsJPLh6uVvRycO0e3HDl3SD5B/QhviUu76tAHpm23xwe0BDqVHGnmC71xQsUKXL5rOsMPg==",
+      "version": "11.27.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.27.0.tgz",
+      "integrity": "sha512-4H1Lfuw1WJYndoCSn+HOoA8JPW0old41FtuKgK+okc/QXmTpw21tK7KL6D+Yu68JEWAksEPssKUeggLAgWkYjA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/feature-flags": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-0.19.0.tgz",
-      "integrity": "sha512-DXpe8rQOh7UCz/iB866CDI2yLUr8I2IHL1NY/y0+vKGs3ALo2fQMWEm5sgdPAXyDbJEKW7NyvVHB+9W00Zpcow==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-0.23.0.tgz",
+      "integrity": "sha512-p98iYUNHPvBQ543hAZ2fbBedYegy3N58eemcqsexWaX0mDdbJNwZCc1fN/HtLvrgKqt70Mal/FKJHlocNRyaNA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/grid": {
-      "version": "11.22.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.22.0.tgz",
-      "integrity": "sha512-b5R4LMRatZ0ZmRh+outCkPIFIF+gvM3sPjC0NAuAc2CQ6lAZP07/m5f8TOX9YAo10kE1j63hU+unEzs6lAHPRA==",
+      "version": "11.28.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.28.0.tgz",
+      "integrity": "sha512-J0E8gGYOOlNfKB4Omks9fJdAI5CmzWF6JvCDndTCcpq58By1atQt9n1C1jvo8iHf84ZDoU1Vd6+ZB9u4fXKdNg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@carbon/layout": "^11.21.0",
-        "@ibm/telemetry-js": "^1.2.1"
+        "@carbon/layout": "^11.27.0",
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/icon-helpers": {
@@ -3850,41 +3850,41 @@
       "integrity": "sha512-6XaySbscz1ubJ/3GtyXB8qJpcAL8kcIzBA6JZpFCcha43tuB1Kps87ADj/v3yx0sLPxyIzRWgkw2n1bnkAcsNA=="
     },
     "node_modules/@carbon/layout": {
-      "version": "11.21.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.21.0.tgz",
-      "integrity": "sha512-R0EEMIzdsWzF2rphzTwDJ6ywnSvDxvZwffBKn7+7bBcTWu0cp/XFeG1UzRL0LoZ25Ixv/aEQYCkoDebgUMfrfQ==",
+      "version": "11.27.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.27.0.tgz",
+      "integrity": "sha512-o2++xUe2Wfg1nzneLl8ucbep9ObUE6vEgwlifVdOpvCti6zlsRjti5ojtYpx3v0yW2Qh7TJH8OYN7CyZDLeZUw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/motion": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.17.0.tgz",
-      "integrity": "sha512-/EXBzFU5hbVxO7yqf/VREesjy8Z6GxhfXjV9etBtj84Z4H460e0CN1z+5KDLpKyq6zVmRnLlFmxVmZgyHwMTfA==",
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.23.0.tgz",
+      "integrity": "sha512-zPxO/lp9FaHET967NHTbQ7pvmqATIQcsiM8WxzNuF2UUNlw6oRL/LMro1eZC9OgKAnyTXRUoxdtYphMhFOXWpA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.56.0.tgz",
-      "integrity": "sha512-NE6A0YasZoHsGwdhzN3/8qsVl7pQHy6qMxjGyGH1MIfJV96ZwR5/3hQSVyWrom+bHsZBUPMgBemImZSX/cdqew==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.67.0.tgz",
+      "integrity": "sha512-enFC5f4VS9pxGZBe1GkUfcbHIgXUAGkRxijN2f5fNtes3/TcPWR1/RGVIelrgjolX5R4keokrrViEOclCsRLmQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@carbon/colors": "^11.21.0",
-        "@carbon/feature-flags": "^0.19.0",
-        "@carbon/grid": "^11.22.0",
-        "@carbon/layout": "^11.21.0",
-        "@carbon/motion": "^11.17.0",
-        "@carbon/themes": "^11.34.0",
-        "@carbon/type": "^11.26.0",
+        "@carbon/colors": "^11.27.0",
+        "@carbon/feature-flags": "^0.23.0",
+        "@carbon/grid": "^11.28.0",
+        "@carbon/layout": "^11.27.0",
+        "@carbon/motion": "^11.23.0",
+        "@carbon/themes": "^11.42.0",
+        "@carbon/type": "^11.32.0",
         "@ibm/plex": "6.0.0-next.6",
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       },
       "peerDependencies": {
         "sass": "^1.33.0"
@@ -3896,16 +3896,16 @@
       }
     },
     "node_modules/@carbon/styles/node_modules/@carbon/themes": {
-      "version": "11.34.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.34.0.tgz",
-      "integrity": "sha512-Dxf5zgk3iuV/MmD4lu2hyScbQmesjE6fol04HPYJeAGtHud2mN+/Ti7H4W3mEcDukIosFNDXKNR39is9+lDTxA==",
+      "version": "11.42.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.42.0.tgz",
+      "integrity": "sha512-f9MslPl8tti9lfx3PLK9GwkJH2D1BXd2nqdLQu0yOELoN92aQiv2eU7ZfJZm6Kuvn1vNoKJpbBey8MmWhEGA8Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@carbon/colors": "^11.21.0",
-        "@carbon/layout": "^11.21.0",
-        "@carbon/type": "^11.26.0",
-        "@ibm/telemetry-js": "^1.2.1",
+        "@carbon/colors": "^11.27.0",
+        "@carbon/layout": "^11.27.0",
+        "@carbon/type": "^11.32.0",
+        "@ibm/telemetry-js": "^1.5.0",
         "color": "^4.0.0"
       }
     },
@@ -3922,15 +3922,15 @@
       }
     },
     "node_modules/@carbon/type": {
-      "version": "11.26.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.26.0.tgz",
-      "integrity": "sha512-Q9ehK/Q68UZjlLE4L+8AfhkNObCksCoGvPb2IMe1IkVoCjJI6QbG3yugGm4D8nfTbs3fGTGAKs4+6HkbkW8Lyw==",
+      "version": "11.32.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.32.0.tgz",
+      "integrity": "sha512-av09976fl4YlaO4HEDs0RG17sg5X0TJbb9m9HfugZjNKDHFbWo87oGLmvgh4J+/ewkC40Wnp24rAewPEaYKFGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@carbon/grid": "^11.22.0",
-        "@carbon/layout": "^11.21.0",
-        "@ibm/telemetry-js": "^1.2.1"
+        "@carbon/grid": "^11.28.0",
+        "@carbon/layout": "^11.27.0",
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/utils-position": {
@@ -37859,31 +37859,31 @@
       }
     },
     "@carbon/colors": {
-      "version": "11.21.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.21.0.tgz",
-      "integrity": "sha512-qvVcguNL+rOfdOv7NsJPLh6uVvRycO0e3HDl3SD5B/QhviUu76tAHpm23xwe0BDqVHGnmC71xQsUKXL5rOsMPg==",
+      "version": "11.27.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.27.0.tgz",
+      "integrity": "sha512-4H1Lfuw1WJYndoCSn+HOoA8JPW0old41FtuKgK+okc/QXmTpw21tK7KL6D+Yu68JEWAksEPssKUeggLAgWkYjA==",
       "dev": true,
       "requires": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "@carbon/feature-flags": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-0.19.0.tgz",
-      "integrity": "sha512-DXpe8rQOh7UCz/iB866CDI2yLUr8I2IHL1NY/y0+vKGs3ALo2fQMWEm5sgdPAXyDbJEKW7NyvVHB+9W00Zpcow==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-0.23.0.tgz",
+      "integrity": "sha512-p98iYUNHPvBQ543hAZ2fbBedYegy3N58eemcqsexWaX0mDdbJNwZCc1fN/HtLvrgKqt70Mal/FKJHlocNRyaNA==",
       "dev": true,
       "requires": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "@carbon/grid": {
-      "version": "11.22.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.22.0.tgz",
-      "integrity": "sha512-b5R4LMRatZ0ZmRh+outCkPIFIF+gvM3sPjC0NAuAc2CQ6lAZP07/m5f8TOX9YAo10kE1j63hU+unEzs6lAHPRA==",
+      "version": "11.28.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.28.0.tgz",
+      "integrity": "sha512-J0E8gGYOOlNfKB4Omks9fJdAI5CmzWF6JvCDndTCcpq58By1atQt9n1C1jvo8iHf84ZDoU1Vd6+ZB9u4fXKdNg==",
       "dev": true,
       "requires": {
-        "@carbon/layout": "^11.21.0",
-        "@ibm/telemetry-js": "^1.2.1"
+        "@carbon/layout": "^11.27.0",
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "@carbon/icon-helpers": {
@@ -37897,50 +37897,50 @@
       "integrity": "sha512-6XaySbscz1ubJ/3GtyXB8qJpcAL8kcIzBA6JZpFCcha43tuB1Kps87ADj/v3yx0sLPxyIzRWgkw2n1bnkAcsNA=="
     },
     "@carbon/layout": {
-      "version": "11.21.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.21.0.tgz",
-      "integrity": "sha512-R0EEMIzdsWzF2rphzTwDJ6ywnSvDxvZwffBKn7+7bBcTWu0cp/XFeG1UzRL0LoZ25Ixv/aEQYCkoDebgUMfrfQ==",
+      "version": "11.27.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.27.0.tgz",
+      "integrity": "sha512-o2++xUe2Wfg1nzneLl8ucbep9ObUE6vEgwlifVdOpvCti6zlsRjti5ojtYpx3v0yW2Qh7TJH8OYN7CyZDLeZUw==",
       "dev": true,
       "requires": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "@carbon/motion": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.17.0.tgz",
-      "integrity": "sha512-/EXBzFU5hbVxO7yqf/VREesjy8Z6GxhfXjV9etBtj84Z4H460e0CN1z+5KDLpKyq6zVmRnLlFmxVmZgyHwMTfA==",
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.23.0.tgz",
+      "integrity": "sha512-zPxO/lp9FaHET967NHTbQ7pvmqATIQcsiM8WxzNuF2UUNlw6oRL/LMro1eZC9OgKAnyTXRUoxdtYphMhFOXWpA==",
       "dev": true,
       "requires": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "@carbon/styles": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.56.0.tgz",
-      "integrity": "sha512-NE6A0YasZoHsGwdhzN3/8qsVl7pQHy6qMxjGyGH1MIfJV96ZwR5/3hQSVyWrom+bHsZBUPMgBemImZSX/cdqew==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.67.0.tgz",
+      "integrity": "sha512-enFC5f4VS9pxGZBe1GkUfcbHIgXUAGkRxijN2f5fNtes3/TcPWR1/RGVIelrgjolX5R4keokrrViEOclCsRLmQ==",
       "dev": true,
       "requires": {
-        "@carbon/colors": "^11.21.0",
-        "@carbon/feature-flags": "^0.19.0",
-        "@carbon/grid": "^11.22.0",
-        "@carbon/layout": "^11.21.0",
-        "@carbon/motion": "^11.17.0",
-        "@carbon/themes": "^11.34.0",
-        "@carbon/type": "^11.26.0",
+        "@carbon/colors": "^11.27.0",
+        "@carbon/feature-flags": "^0.23.0",
+        "@carbon/grid": "^11.28.0",
+        "@carbon/layout": "^11.27.0",
+        "@carbon/motion": "^11.23.0",
+        "@carbon/themes": "^11.42.0",
+        "@carbon/type": "^11.32.0",
         "@ibm/plex": "6.0.0-next.6",
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       },
       "dependencies": {
         "@carbon/themes": {
-          "version": "11.34.0",
-          "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.34.0.tgz",
-          "integrity": "sha512-Dxf5zgk3iuV/MmD4lu2hyScbQmesjE6fol04HPYJeAGtHud2mN+/Ti7H4W3mEcDukIosFNDXKNR39is9+lDTxA==",
+          "version": "11.42.0",
+          "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.42.0.tgz",
+          "integrity": "sha512-f9MslPl8tti9lfx3PLK9GwkJH2D1BXd2nqdLQu0yOELoN92aQiv2eU7ZfJZm6Kuvn1vNoKJpbBey8MmWhEGA8Q==",
           "dev": true,
           "requires": {
-            "@carbon/colors": "^11.21.0",
-            "@carbon/layout": "^11.21.0",
-            "@carbon/type": "^11.26.0",
-            "@ibm/telemetry-js": "^1.2.1",
+            "@carbon/colors": "^11.27.0",
+            "@carbon/layout": "^11.27.0",
+            "@carbon/type": "^11.32.0",
+            "@ibm/telemetry-js": "^1.5.0",
             "color": "^4.0.0"
           }
         }
@@ -37959,14 +37959,14 @@
       }
     },
     "@carbon/type": {
-      "version": "11.26.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.26.0.tgz",
-      "integrity": "sha512-Q9ehK/Q68UZjlLE4L+8AfhkNObCksCoGvPb2IMe1IkVoCjJI6QbG3yugGm4D8nfTbs3fGTGAKs4+6HkbkW8Lyw==",
+      "version": "11.32.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.32.0.tgz",
+      "integrity": "sha512-av09976fl4YlaO4HEDs0RG17sg5X0TJbb9m9HfugZjNKDHFbWo87oGLmvgh4J+/ewkC40Wnp24rAewPEaYKFGw==",
       "dev": true,
       "requires": {
-        "@carbon/grid": "^11.22.0",
-        "@carbon/layout": "^11.21.0",
-        "@ibm/telemetry-js": "^1.2.1"
+        "@carbon/grid": "^11.28.0",
+        "@carbon/layout": "^11.27.0",
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "@carbon/utils-position": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@angular/platform-browser-dynamic": "14.3.0",
     "@angular/router": "14.3.0",
     "@babel/core": "7.9.6",
-    "@carbon/styles": "1.56.0",
+    "@carbon/styles": "1.67.0",
     "@carbon/themes": "11.24.0",
     "@commitlint/cli": "17.0.3",
     "@commitlint/config-conventional": "17.0.3",

--- a/src/pagination/pagination-nav.stories.ts
+++ b/src/pagination/pagination-nav.stories.ts
@@ -29,7 +29,8 @@ const Template = (args) => ({
 			[disabled]="disabled"
 			[totalDataLength]="totalDataLength"
 			[numOfItemsToShow]="numOfItemsToShow"
-			[skeleton]="skeleton">
+			[skeleton]="skeleton"
+			[size]="size">
 		</app-pagination>
 	`
 });
@@ -38,5 +39,6 @@ Basic.args = {
 	disabled: false,
 	totalDataLength: 10,
 	numOfItemsToShow: 4,
-	skeleton: false
+	skeleton: false,
+	size: "md"
 };

--- a/src/pagination/pagination-nav/pagination-nav.component.ts
+++ b/src/pagination/pagination-nav/pagination-nav.component.ts
@@ -149,13 +149,13 @@ export class PaginationNav {
 	@Input() size: "sm" | "md" | "lg" = "lg";
 
 	// Size
-	@HostBinding("class.cds--layout--size-sm") get sizeSm() {
+	@HostBinding("class.cds--layout--size-sm") get smallSize() {
 		return this.size === "sm";
 	}
-	@HostBinding("class.cds--layout--size-md") get sizeMd() {
+	@HostBinding("class.cds--layout--size-md") get mediumSize() {
 		return this.size === "md";
 	}
-	@HostBinding("class.cds--layout--size-lg") get sizeLg() {
+	@HostBinding("class.cds--layout--size-lg") get largeSize() {
 		return this.size === "lg";
 	}
 

--- a/src/pagination/pagination-nav/pagination-nav.component.ts
+++ b/src/pagination/pagination-nav/pagination-nav.component.ts
@@ -149,13 +149,13 @@ export class PaginationNav {
 	@Input() size: "sm" | "md" | "lg" = "lg";
 
 	// Size
-	@HostBinding("class.cds--layout--size-sm") get smallSize() {
+	@HostBinding("class.cds--layout--size-sm") get smallLayoutSize() {
 		return this.size === "sm";
 	}
-	@HostBinding("class.cds--layout--size-md") get mediumSize() {
+	@HostBinding("class.cds--layout--size-md") get mediumLayoutSize() {
 		return this.size === "md";
 	}
-	@HostBinding("class.cds--layout--size-lg") get largeSize() {
+	@HostBinding("class.cds--layout--size-lg") get largeLayoutSize() {
 		return this.size === "lg";
 	}
 

--- a/src/pagination/pagination-nav/pagination-nav.component.ts
+++ b/src/pagination/pagination-nav/pagination-nav.component.ts
@@ -3,7 +3,8 @@ import {
 	Component,
 	Input,
 	Output,
-	EventEmitter
+	EventEmitter,
+	HostBinding
 } from "@angular/core";
 
 import { I18n, Overridable } from "carbon-components-angular/i18n";
@@ -51,7 +52,7 @@ export interface PaginationNavTranslations {
 				<li class="cds--pagination-nav__list-item">
 					<cds-icon-button
 						kind="ghost"
-						size="md"
+						[size]="size"
 						(click)="jumpToPrevious()"
 						[disabled]="leftArrowDisabled"
 						[description]="previousItemText.subject | async">
@@ -95,6 +96,7 @@ export interface PaginationNavTranslations {
 				<li class="cds--pagination-nav__list-item">
 					<cds-icon-button
 						kind="ghost"
+						[size]="size"
 						(click)="jumpToNext()"
 						[disabled]="rightArrowDisabled"
 						[description]="nextItemText.subject | async">
@@ -139,6 +141,22 @@ export class PaginationNav {
 		const valueWithDefaults = merge(this.i18n.getMultiple("PAGINATION"), value);
 		this.nextItemText.override(valueWithDefaults.NEXT);
 		this.previousItemText.override(valueWithDefaults.PREVIOUS);
+	}
+
+	/**
+	 * Sets the pagination nav size
+	 */
+	@Input() size: "sm" | "md" | "lg" = "lg";
+
+	// Size
+	@HostBinding("class.cds--layout--size-sm") get sizeSm() {
+		return this.size === "sm";
+	}
+	@HostBinding("class.cds--layout--size-md") get sizeMd() {
+		return this.size === "md";
+	}
+	@HostBinding("class.cds--layout--size-lg") get sizeLg() {
+		return this.size === "lg";
 	}
 
 	/**

--- a/src/pagination/pagination-nav/stories/pagination-nav-story.component.ts
+++ b/src/pagination/pagination-nav/stories/pagination-nav-story.component.ts
@@ -13,7 +13,8 @@ import { PaginationModel } from "../..";
 			[model]="model"
 			[disabled]="disabled"
 			(selectPage)="selectPage($event)"
-			[numOfItemsToShow]="numOfItemsToShow">
+			[numOfItemsToShow]="numOfItemsToShow"
+			[size]="size">
 		</cds-pagination-nav>
 	`
 })
@@ -22,6 +23,7 @@ export class PaginationNavStory implements OnInit {
 	@Input() disabled = false;
 	@Input() pageInputDisabled = false;
 	@Input() numOfItemsToShow = false;
+	@Input() size: "sm" | "md" | "lg" = "md";
 
 	@Input() get totalDataLength() {
 		return this.model.totalDataLength;


### PR DESCRIPTION
### Allow specifying a size for the pagination nav component as is documented in spec.
<img width="736" alt="pagination" src="https://github.com/user-attachments/assets/b21a3a41-1319-484c-920b-a04f2301aca2">
    
[carbon spec](https://carbondesignsystem.com/components/pagination/usage/)

#### Changelog

**New**

* New size property for pagination nav component `sm, md, lg` defaults to `lg` as this is default now.

**Changed**

* had to bump carbon/styles version to 1.67
* updated storybook


https://github.com/user-attachments/assets/6de070bd-8a1e-4bef-811e-25bc16805744


