### PR TITLE
fix: add 'aria-' prefix to accessibility attributes

### DIFF
--- a/src/progress-bar/progress-bar.component.ts
+++ b/src/progress-bar/progress-bar.component.ts
@@ -42,8 +42,8 @@ import {
 			class="cds--progress-bar__track"
 			role="progressbar"
 			[attr.aria-invalid]="isError"
-			[attr.labelledby]="id"
-			[attr.describedby]="helperText ? helperId: null"
+			[attr.aria-labelledby]="id"
+			[attr.aria-describedby]="helperText ? helperId : null"
 			[attr.aria-valuemin]="!indeterminate ? 0 : null"
 			[attr.aria-valuemax]="!indeterminate ? max : null"
 			[attr.aria-valuenow]="!indeterminate ? value : null">


### PR DESCRIPTION
Correct accessibility attributes in progress-bar

#### Changelog

**Changed**

* add 'aria-' prefix to accessibility attributes
