### PR TITLE
fix: mark event service as deprecated and unsubscribe from fromEvent observables

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu.stories.ts
+++ b/src/dialog/overflow-menu/overflow-menu.stories.ts
@@ -33,7 +33,11 @@ export default {
 const Template = (args) => ({
 	props: args,
 	template: `
+		<button (click)="show=!show">Click me!</button>
+		<br/><br/><br/><br/><br/><br/>
+
 		<cds-overflow-menu
+			*ngIf="show"
 			[placement]="placement"
 			[open]="open"
 			[flip]="flip"
@@ -50,10 +54,13 @@ const Template = (args) => ({
 			<cds-overflow-menu-option type="danger" (selected)="selected($event)">Danger option</cds-overflow-menu-option>
 		</cds-overflow-menu>
 		<cds-placeholder></cds-placeholder>
+
+
 	`
 });
 export const Basic = Template.bind({});
 Basic.args = {
+	show: true,
 	open: false,
 	flip: false,
 	offset: {

--- a/src/toggletip/toggletip.component.ts
+++ b/src/toggletip/toggletip.component.ts
@@ -9,9 +9,10 @@ import {
 	HostListener,
 	Input,
 	NgZone,
+	OnDestroy,
 	Renderer2
 } from "@angular/core";
-import { fromEvent } from "rxjs";
+import { fromEvent, Subscription } from "rxjs";
 import { PopoverContainer } from "carbon-components-angular/popover";
 import { ToggletipButton } from "./toggletip-button.directive";
 
@@ -34,7 +35,7 @@ import { ToggletipButton } from "./toggletip-button.directive";
 		</cds-popover-content>
 	`
 })
-export class Toggletip extends PopoverContainer implements AfterViewInit {
+export class Toggletip extends PopoverContainer implements AfterViewInit, OnDestroy {
 	static toggletipCounter = 0;
 
 	@Input() id = `tooltip-${Toggletip.toggletipCounter++}`;
@@ -45,6 +46,7 @@ export class Toggletip extends PopoverContainer implements AfterViewInit {
 	@ContentChild(ToggletipButton, { read: ElementRef }) btn!: ElementRef;
 
 	documentClick = this.handleFocusOut.bind(this);
+	private subscription: Subscription;
 
 	constructor(
 		protected hostElement: ElementRef,
@@ -61,7 +63,7 @@ export class Toggletip extends PopoverContainer implements AfterViewInit {
 		this.initializeReferences();
 
 		// Listen for click events on trigger
-		fromEvent(this.btn.nativeElement, "click")
+		this.subscription = fromEvent(this.btn.nativeElement, "click")
 			.subscribe((event: Event) => {
 				// Add/Remove event listener based on isOpen to improve performance when there
 				// are a lot of toggletips
@@ -96,6 +98,10 @@ export class Toggletip extends PopoverContainer implements AfterViewInit {
 		if (!this.hostElement.nativeElement.contains(event.target)) {
 			this.handleExpansion(false, event);
 		}
+	}
+
+	ngOnDestroy(): void {
+		this.subscription.unsubscribe();
 	}
 
 	private handleExpansion(state = false, event: Event) {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#3003

Event service will be removed in v6 in favor of using `fromEvent` (which is what EventService is using under the hood). In v6, dialog directive won't be used for overflow menu when we switch to using `floating-ui` for positioning.

#### Changelog

**Changed**

* Removed usage of `EventService` in dialog in favor of simply calling FromEvent and unsubscribing on destroy.
