### PR TITLE
fix: refresh view after content is initialized

### DIFF
--- a/integration/ng17/angular.json
+++ b/integration/ng17/angular.json
@@ -40,7 +40,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/src/input/text-input-label.component.ts
+++ b/src/input/text-input-label.component.ts
@@ -1,4 +1,5 @@
 import {
+	AfterContentInit,
 	AfterViewInit,
 	ChangeDetectorRef,
 	Component,
@@ -102,7 +103,7 @@ import {
 		</div>
 	`
 })
-export class TextInputLabelComponent implements AfterViewInit {
+export class TextInputLabelComponent implements AfterViewInit, AfterContentInit {
 	/**
 	 * Used to build the id of the input item associated with the `Label`.
 	 */
@@ -208,6 +209,10 @@ export class TextInputLabelComponent implements AfterViewInit {
 				divElement.setAttribute("id", this.labelInputID);
 			}
 		}
+	}
+
+	ngAfterContentInit() {
+		this.changeDetectorRef.detectChanges();
 	}
 
 	public isTemplate(value) {


### PR DESCRIPTION
Resolve expression has changed (NG0100) for input readonly state 

#### Changelog

**Changed**

* Manually trigger change detection when content is initialized
