### PR TITLE
fix: Remove hardcoded check in pagination select icon condition

### DIFF
--- a/src/pagination/pagination.component.spec.ts
+++ b/src/pagination/pagination.component.spec.ts
@@ -174,4 +174,22 @@ describe("Pagination", () => {
 		fixture.detectChanges();
 		expect(wrapper.pageOptions).toEqual(Array(1));
 	});
+
+	it("should replace the select with a number input when the pagination threshold is reached", () => {
+		const fixture = TestBed.createComponent(PaginationTest);
+		const wrapper = fixture.componentInstance;
+		fixture.detectChanges();
+		element = fixture.debugElement.query(By.css("cds-pagination"));
+
+		element.componentInstance.pageSelectThreshold = 500;
+		fixture.detectChanges();
+		expect(element.nativeElement.querySelector(".cds--select__page-number input")).toBe(null);
+		expect(element.nativeElement.querySelector(".cds--select__page-number select")).toBeDefined();
+
+		element.componentInstance.pageSelectThreshold = 2;
+		fixture.detectChanges();
+		expect(element.nativeElement.querySelector(".cds--select__page-number input")).toBeDefined();
+		expect(element.nativeElement.querySelector(".cds--select__page-number select")).toBe(null);
+
+	});
 });

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -137,7 +137,7 @@ export interface PaginationTranslations {
 						<option *ngFor="let page of pageOptions; let i = index;" class="cds--select-option" [value]="i + 1">{{i + 1}}</option>
 					</select>
 					<svg
-						*ngIf="pageOptions.length <= 1000"
+						*ngIf="pageOptions.length <= pageSelectThreshold"
 						cdsIcon="chevron--down"
 						size="16"
 						style="display: inherit;"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#3075

The check to show/hide the cdsIcon had a hardcoded value, whereas the select box next to it was using `pageSelectThreshold`. The hardcoded value was replaced by the input variable and unit tests where added for this part of the component

#### Changelog

**Changed**
- Replace hardcoded value with `pageSelectThreshold`