### PR TITLE
fix: remove application ref tick to improve performane

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -25,7 +25,6 @@ import {
 
 import { AbstractDropdownView } from "./abstract-dropdown-view.class";
 import { I18n } from "carbon-components-angular/i18n";
-import { ListItem } from "./list-item.interface";
 import { DropdownService } from "./dropdown.service";
 import { ElementService, getScrollableParents } from "carbon-components-angular/utils";
 import { hasScrollableParents } from "carbon-components-angular/utils";

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -9,10 +9,14 @@ import {
 	ViewChild,
 	ElementRef,
 	ViewChildren,
-	QueryList,
-	ApplicationRef
+	QueryList
 } from "@angular/core";
-import { Observable, isObservable, Subscription, of } from "rxjs";
+import {
+	Observable,
+	isObservable,
+	Subscription,
+	of
+} from "rxjs";
 import { first } from "rxjs/operators";
 
 import { I18n } from "carbon-components-angular/i18n";
@@ -224,7 +228,7 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	/**
 	 * Creates an instance of `DropdownList`.
 	 */
-	constructor(public elementRef: ElementRef, protected i18n: I18n, protected appRef: ApplicationRef) {}
+	constructor(public elementRef: ElementRef, protected i18n: I18n) {}
 
 	/**
 	 * Retrieves array of list items and index of the selected item after view has rendered.
@@ -564,7 +568,6 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 			this.index = this.displayItems.indexOf(item);
 			this.highlightedItem = this.getItemId(this.index);
 			this.doEmitSelect(false);
-			this.appRef.tick();
 		}
 	}
 


### PR DESCRIPTION
Remove ApplicationRef.tick in dropdownlist.

#### Changelog

**Removed**

* Remove application ref tick to prevent running change detection for the entire application. Verified removing `tick()` does not cause issues when disabling the first item via storybook. Also verified passing in a new array with setTimeout.