### PR TITLE
feat: convert components to use OnPush change detection strategy 

### DIFF
--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -135,7 +135,9 @@ export class Overridable {
 /**
  * An object of strings, should follow the same format as src/i18n/en.json
  */
-export type TranslationStrings = { [key: string]: string };
+export type TranslationStrings = {
+	[key: string]: string | TranslationStrings;
+};
 
 
 /**
@@ -148,7 +150,7 @@ export type TranslationStrings = { [key: string]: string };
  */
 @Injectable()
 export class I18n {
-	protected translationStrings = EN;
+	protected translationStrings: TranslationStrings = EN;
 
 	protected translations = new Map();
 
@@ -264,8 +266,8 @@ export class I18n {
 	 *
 	 * @param path looks like `"NOTIFICATION.CLOSE_BUTTON"`
 	 */
-	public getValueFromPath(path): string | { [key: string]: string } {
-		let value = this.translationStrings;
+	public getValueFromPath(path: string): string | TranslationStrings {
+		let value: string | TranslationStrings = this.translationStrings;
 		for (const segment of path.split(".")) {
 			if (value[segment] !== undefined && value[segment] !== null) {
 				value = value[segment];

--- a/src/loading/loading.component.ts
+++ b/src/loading/loading.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, HostBinding } from "@angular/core";
+import { Component, Input, HostBinding, ChangeDetectionStrategy } from "@angular/core";
 import { I18n } from "carbon-components-angular/i18n";
 
 /**
@@ -25,7 +25,8 @@ import { I18n } from "carbon-components-angular/i18n";
 				<circle class="cds--loading__stroke" cx="50%" cy="50%" r="44" />
 			</svg>
 		</div>
-	`
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class Loading {
 	/**

--- a/src/number-input/number.component.spec.ts
+++ b/src/number-input/number.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
-import { Number } from "./number.component";
 import { FormsModule } from "@angular/forms";
 import { I18nModule } from "../i18n/index";
 import { IconModule } from "../icon/index";
+import { Number } from "./number.component";
 
 describe("Number", () => {
 	let component: Number;
@@ -77,7 +77,7 @@ describe("Number", () => {
 		expect(labelElement.innerHTML.includes("Number Input")).toEqual(true);
 		expect(containerElement.className.includes("cds--number--nolabel")).toEqual(false);
 
-		component.label = null;
+		fixture.componentRef.setInput("label", null);
 		fixture.detectChanges();
 		expect(fixture.debugElement.query(By.css(".cds--label"))).toBeNull();
 		expect(containerElement.className.includes("cds--number--nolabel")).toEqual(true);
@@ -186,10 +186,10 @@ describe("Number", () => {
 	});
 
 	it("should have dark and light theme", () => {
-		component.theme = "dark";
+		fixture.componentRef.setInput("theme", "dark");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--number--light")).toEqual(false);
-		component.theme = "light";
+		fixture.componentRef.setInput("theme", "light");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--number--light")).toEqual(true);
 	});

--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -1,11 +1,12 @@
 import {
+	ChangeDetectionStrategy,
 	Component,
-	Input,
-	HostBinding,
 	EventEmitter,
+	HostBinding,
+	HostListener,
+	Input,
 	Output,
-	TemplateRef,
-	HostListener
+	TemplateRef
 } from "@angular/core";
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
@@ -144,7 +145,8 @@ export class NumberChange {
 			useExisting: NumberComponent,
 			multi: true
 		}
-	]
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NumberComponent implements ControlValueAccessor {
 	/**

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -1,8 +1,9 @@
 import {
+	ChangeDetectionStrategy,
 	Component,
+	EventEmitter,
 	Input,
-	Output,
-	EventEmitter
+	Output
 } from "@angular/core";
 import { I18n } from "carbon-components-angular/i18n";
 import { Step } from "./progress-indicator-step.interface";
@@ -67,7 +68,8 @@ import { Step } from "./progress-indicator-step.interface";
 			</button>
 		</li>
 	</ul>
-	`
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ProgressIndicator {
 	@Input() get current() {

--- a/src/search/search.component.spec.ts
+++ b/src/search/search.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
-import { Search } from "./search.component";
 import { FormsModule } from "@angular/forms";
 import { I18nModule } from "../i18n/index";
 import { IconModule } from "../icon/index";
+import { Search } from "./search.component";
 
 describe("Search", () => {
 	let component: Search;
@@ -23,7 +23,7 @@ describe("Search", () => {
 			],
 			providers: []
 		})
-		.compileComponents();
+			.compileComponents();
 	}));
 
 	beforeEach(() => {
@@ -38,46 +38,46 @@ describe("Search", () => {
 	});
 
 	it("should bind input value", () => {
-		component.value = "Text";
+		fixture.componentRef.setInput("value", "Text");
 		fixture.detectChanges();
 		expect(inputElement.value).toEqual("Text");
 	});
 
 	it("should bind input disabled", () => {
 		expect(inputElement.disabled).toEqual(false);
-		component.disabled = true;
+		fixture.componentRef.setInput("disabled", true);
 		fixture.detectChanges();
 		expect(inputElement.disabled).toEqual(true);
 	});
 
 	it("should bind input required", () => {
-		component.required = true;
+		fixture.componentRef.setInput("required", true);
 		fixture.detectChanges();
 		expect(inputElement.required).toEqual(true);
 	});
 
 	it("should display component of the correct size", () => {
 		containerElement = fixture.debugElement.query(By.css(".cds--search")).nativeElement;
-		component.size = "lg";
+		fixture.componentRef.setInput("size", "lg");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--search--lg")).toEqual(true);
-		component.size = "sm";
+		fixture.componentRef.setInput("size", "sm");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--search--sm")).toEqual(true);
 	});
 
 	it("should display clear button", () => {
 		clearButtonElement = fixture.debugElement.query(By.css("button")).nativeElement;
-		component.value = "";
+		fixture.componentRef.setInput("value", "");
 		fixture.detectChanges();
 		expect(clearButtonElement.className.includes("cds--search-close--hidden")).toEqual(true);
-		component.value = "Text";
+		fixture.componentRef.setInput("value", "Text");
 		fixture.detectChanges();
 		expect(clearButtonElement.className.includes("cds--search-close--hidden")).toEqual(false);
 	});
 
 	it("should clear input when clear button is clicked", () => {
-		component.value = "Text";
+		fixture.componentRef.setInput("value", "Text");
 		fixture.detectChanges();
 		clearButtonElement = fixture.debugElement.query(By.css("button")).nativeElement;
 		clearButtonElement.click();
@@ -87,7 +87,7 @@ describe("Search", () => {
 
 	it("should clear the input when the clear button is clicked on the expandable component", () => {
 		component.expandable = true;
-		component.value = "TextToClear";
+		fixture.componentRef.setInput("value", "TextToClear");
 		fixture.detectChanges();
 		clearButtonElement = fixture.debugElement.query(By.css("button")).nativeElement;
 		clearButtonElement.click();
@@ -97,7 +97,7 @@ describe("Search", () => {
 
 	it("should clear the input when the escape key is pressed", () => {
 		clearButtonElement = fixture.debugElement.query(By.css("button")).nativeElement;
-		component.value = "TextToClear";
+		fixture.componentRef.setInput("value", "TextToClear");
 		fixture.detectChanges();
 		expect(clearButtonElement.className.includes("cds--search-close--hidden")).toEqual(false);
 		component.keyDown(new KeyboardEvent("keydown", {
@@ -109,10 +109,10 @@ describe("Search", () => {
 	});
 
 	it("should clear the input and keep the expanded state open when the escape key is pressed", () => {
-		component.expandable = true;
-		component.active = true;
+		fixture.componentRef.setInput("expandable", true);
+		fixture.componentRef.setInput("active", true);
 		containerElement = fixture.debugElement.query(By.css(".cds--search")).nativeElement;
-		component.value = "TextToClear";
+		fixture.componentRef.setInput("value", "TextToClear");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--search--expanded")).toEqual(true);
 		component.keyDown(new KeyboardEvent("keydown", {
@@ -124,10 +124,10 @@ describe("Search", () => {
 	});
 
 	it("should close the expandable search component when esc is pressed when content is empty", () => {
-		component.expandable = true;
-		component.active = true;
+		fixture.componentRef.setInput("expandable", true);
+		fixture.componentRef.setInput("active", true);
 		containerElement = fixture.debugElement.query(By.css(".cds--search")).nativeElement;
-		component.value = "";
+		fixture.componentRef.setInput("value", "");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--search--expanded")).toEqual(true);
 		component.keyDown(new KeyboardEvent("keydown", {
@@ -140,10 +140,10 @@ describe("Search", () => {
 
 	it("should have dark and light theme", () => {
 		containerElement = fixture.debugElement.query(By.css(".cds--search")).nativeElement;
-		component.theme = "dark";
+		fixture.componentRef.setInput("theme", "dark");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--search--light")).toEqual(false);
-		component.theme = "light";
+		fixture.componentRef.setInput("theme", "light");
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--search--light")).toEqual(true);
 	});

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -8,7 +8,7 @@ import {
 	HostListener,
 	Input,
 	Output,
-	ViewChild,
+	ViewChild
 } from "@angular/core";
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 import { I18n } from "carbon-components-angular/i18n";
@@ -29,10 +29,10 @@ import { I18n } from "carbon-components-angular/i18n";
 		{
 			provide: NG_VALUE_ACCESSOR,
 			useExisting: Search,
-			multi: true,
-		},
+			multi: true
+		}
 	],
-	changeDetection: ChangeDetectionStrategy.OnPush,
+	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class Search implements ControlValueAccessor {
 	/**

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -1,14 +1,16 @@
 import {
+	ChangeDetectionStrategy,
+	ChangeDetectorRef,
 	Component,
-	Input,
-	EventEmitter,
-	Output,
-	HostBinding,
 	ElementRef,
+	EventEmitter,
+	HostBinding,
 	HostListener,
-	ViewChild
+	Input,
+	Output,
+	ViewChild,
 } from "@angular/core";
-import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 import { I18n } from "carbon-components-angular/i18n";
 
 /**
@@ -27,9 +29,10 @@ import { I18n } from "carbon-components-angular/i18n";
 		{
 			provide: NG_VALUE_ACCESSOR,
 			useExisting: Search,
-			multi: true
-		}
-	]
+			multi: true,
+		},
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Search implements ControlValueAccessor {
 	/**
@@ -41,7 +44,8 @@ export class Search implements ControlValueAccessor {
 		return !(this.toolbar || this.expandable);
 	}
 
-	@HostBinding("class.cds--text-input--fluid__skeleton") get fluidSkeletonClass() {
+	@HostBinding("class.cds--text-input--fluid__skeleton")
+	get fluidSkeletonClass() {
 		return this.skeleton && this.fluid;
 	}
 
@@ -151,7 +155,11 @@ export class Search implements ControlValueAccessor {
 	 * Creates an instance of `Search`.
 	 * @param i18n The i18n translations.
 	 */
-	constructor(protected elementRef: ElementRef, protected i18n: I18n) {
+	constructor(
+		protected elementRef: ElementRef,
+		protected i18n: I18n,
+		protected cdr: ChangeDetectorRef
+	) {
 		Search.searchCount++;
 	}
 
@@ -193,7 +201,8 @@ export class Search implements ControlValueAccessor {
 	 * @param search The input text.
 	 */
 	onSearch(search: string) {
-		if (this.isComposing) { // check for IME use
+		if (this.isComposing) {
+			// check for IME use
 			return;
 		}
 		this.value = search;
@@ -234,6 +243,7 @@ export class Search implements ControlValueAccessor {
 				if (this.value === "") {
 					this.active = false;
 					this.open.emit(this.active);
+					this.cdr.markForCheck();
 				}
 			} else if (event.key === "Enter") {
 				this.openSearch();
@@ -243,6 +253,7 @@ export class Search implements ControlValueAccessor {
 		if (event.key === "Escape") {
 			if (this.value !== "") {
 				this.clearSearch();
+				this.cdr.markForCheck();
 			}
 		}
 	}
@@ -250,10 +261,14 @@ export class Search implements ControlValueAccessor {
 	@HostListener("focusout", ["$event"])
 	focusOut(event) {
 		this.onTouched();
-		if ((this.expandable || this.toolbar) &&
+		if (
+			(this.expandable || this.toolbar) &&
 			this.inputRef &&
 			this.inputRef.nativeElement.value === "" &&
-			!(this.elementRef.nativeElement as HTMLElement).contains(event.relatedTarget)) {
+			!(this.elementRef.nativeElement as HTMLElement).contains(
+				event.relatedTarget
+			)
+		) {
 			this.active = false;
 			this.open.emit(this.active);
 		}
@@ -263,9 +278,14 @@ export class Search implements ControlValueAccessor {
 	focusIn(event) {
 		this.onTouched();
 		// set input focus if search icon get focus from tab key press event.
-		if ((this.expandable || this.toolbar) &&
-			this.inputRef && !event.relatedTarget &&
-			!(this.elementRef.nativeElement as HTMLElement).contains(event.relatedTarget) ) {
+		if (
+			(this.expandable || this.toolbar) &&
+			this.inputRef &&
+			!event.relatedTarget &&
+			!(this.elementRef.nativeElement as HTMLElement).contains(
+				event.relatedTarget
+			)
+		) {
 			this.openSearch();
 		}
 	}

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -1,11 +1,12 @@
 import {
 	AfterViewInit,
+	ChangeDetectionStrategy,
 	Component,
 	ElementRef,
+	EventEmitter,
+	HostListener,
 	Input,
 	Output,
-	HostListener,
-	EventEmitter,
 	TemplateRef,
 	ViewChild
 } from "@angular/core";
@@ -164,7 +165,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 			useExisting: Select,
 			multi: true
 		}
-	]
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class Select implements ControlValueAccessor, AfterViewInit {
 	@Input() set value(v) {


### PR DESCRIPTION
Update components to use On Push, part of  [issue-3066](https://github.com/carbon-design-system/carbon-components-angular/issues/3066)

#### Changelog

**Changed**

Select + fix unit tests
Loader
Progress
Number input + fix unit tests

While migrating components to use OnPush change detection, some unit tests started failing. The issue was that the fixture wasn't updating to new input values even when using `fixture.detectChanges()`.

My research revealed that Angular v14 introduced a new API for setting input properties for `fixture.componentRef`: `setInput` ([commit](https://github.com/angular/angular/commit/96c6139c9ab35aa6ab2330a5a79a5906d5c2e8be)) that seems to work as before.

However, using `fixture.componentRef.setInput(propertyName, value)` didn't resolve all test failures. I had to manually trigger change detection in those cases.

If my approach is incorrect, please let me know the best way to handle these unit testing scenarios.
