### PR TITLE
ci: bump deprecated version of GH action and resolve integration test build issue

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -29,7 +29,7 @@ jobs:
         cd dist
         npm pack
     - name: Upload dist
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/carbon-components-angular-0.0.0.tgz

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Download dist
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: dist
     - run: |

--- a/integration/ng15/angular.json
+++ b/integration/ng15/angular.json
@@ -40,7 +40,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
CI jobs are starting to fail since `master` branch is using a deprecated GH action. This PR bumps the following actions:
* upload-artifact - v3 -> v4
* download-artifact - v3 -> v4

Additionally, PR bumps budget for angular 15 build. Doubled, in case future dependabot changes increase build size.