### PR TITLE
fix(dialog): Remove the incorrect descendant element

### DIFF
--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -117,7 +117,7 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 
 	@HostBinding("attr.role") role = "button";
 	@HostBinding("attr.aria-haspopup") hasPopup = true;
-	@HostBinding("attr.aria-owns") get ariaOwns(): string {
+	@HostBinding("attr.aria-controls") get ariaControls(): string {
 		return this.isOpen ? this.dialogConfig.compID : null;
 	}
 


### PR DESCRIPTION

Violation : The element with role "button" contains descendants with roles "dialog" which are ignored by browsers

<img width="1694" alt="accessibility-violation" src="https://github.com/user-attachments/assets/c8b68ed5-f495-44df-b57b-7924a9315aa9" />

Fix : The accessibility violation occurs because aria-owns moves the dialog inside the button in the accessibility tree, which is not valid for a button element.

