### PR TITLE
fix: count character length when using NgControl

### DIFF
--- a/src/input/input.directive.ts
+++ b/src/input/input.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, HostBinding, Input } from "@angular/core";
+import { Directive, HostBinding, Input, Optional, Self } from "@angular/core";
+import { NgControl } from "@angular/forms";
 
 /**
  * A directive for applying styling to an input element.
@@ -63,4 +64,5 @@ export class TextInput {
 		return this.invalid ? true : undefined;
 	}
 
+	constructor(@Self() @Optional() public ngControl: NgControl) {}
 }

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -6,12 +6,19 @@ import { AILabelModule } from "../ai-label";
 import { ButtonModule } from "../button";
 import { IconModule } from "../icon";
 import { AI_LABEL_INNER, AI_LABEL_STORY_STYLES } from "../storybook/ai-label-story-shared";
+import { FormsModule } from "@angular/forms";
 
 export default {
 	title: "Components/Input",
 	decorators: [
 		moduleMetadata({
-			imports: [InputModule, AILabelModule, ButtonModule, IconModule]
+			imports: [
+				InputModule,
+				AILabelModule,
+				ButtonModule,
+				IconModule,
+				FormsModule
+			]
 		})
 	],
 	args: {

--- a/src/input/text-area.directive.ts
+++ b/src/input/text-area.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, HostBinding, Input } from "@angular/core";
+import { Directive, HostBinding, Input, Optional, Self } from "@angular/core";
+import { NgControl } from "@angular/forms";
 
 /**
  * A directive for applying styling to a textarea element.
@@ -35,4 +36,6 @@ export class TextArea {
 	@HostBinding("attr.data-invalid") get getInvalidAttr() {
 		return this.invalid ? true : undefined;
 	}
+
+	constructor(@Self() @Optional() public ngControl: NgControl) {}
 }

--- a/src/input/text-input-label.component.ts
+++ b/src/input/text-input-label.component.ts
@@ -3,6 +3,7 @@ import {
 	AfterViewInit,
 	ChangeDetectorRef,
 	Component,
+	ContentChild,
 	ElementRef,
 	HostBinding,
 	Input,
@@ -12,6 +13,9 @@ import {
 	TemplateRef,
 	ViewChild
 } from "@angular/core";
+import { Subscription } from "rxjs";
+import { startWith } from "rxjs/operators";
+import { TextInput } from "./input.directive";
 
 /**
  * Get started with importing the module:
@@ -269,13 +273,20 @@ export class TextInputLabelComponent implements AfterViewInit, AfterContentInit,
 	// @ts-ignore
 	@ViewChild("wrapper", { static: false }) wrapper: ElementRef<HTMLDivElement>;
 
+	// @ts-ignore
+	@ContentChild(TextInput, { static: false }) textInput: TextInput;
+
 	@HostBinding("class.cds--form-item") labelClass = true;
 
 	@HostBinding("class.cds--text-input-wrapper") textInputWrapper = true;
 
 	// Cached reference to the input element, set once in ngAfterViewInit.
 	private _inputElement: HTMLInputElement | null = null;
-	// Cached listener so it can be removed precisely (avoids anonymous-function leak).
+
+	// RxJS subscription used when NgControl is available (template-driven & reactive forms).
+	private _subscription: Subscription | null = null;
+
+	// Fallback cached DOM listener so it can be removed precisely (avoids anonymous-function leak).
 	private _inputListener: ((e: Event) => void) | null = null;
 
 	/**
@@ -321,8 +332,7 @@ export class TextInputLabelComponent implements AfterViewInit, AfterContentInit,
 	}
 
 	/**
-	 * Attach/remove listener and seed `textCount` from the textarea's current value.
-	 * @param changes
+	 * Attach/remove listener and seed `textCount` from the input's current value.
 	 */
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.enableCounter && !changes.enableCounter.firstChange) {
@@ -351,24 +361,42 @@ export class TextInputLabelComponent implements AfterViewInit, AfterContentInit,
 	}
 
 	/**
-	 * Attaches the input event listener, ensuring it is never added twice.
+	 * Attaches the counter listener, listen for either ngControl or native DOM input
+	 * event listener
 	 */
 	private _attachCounterListener(): void {
 		this._detachCounterListener();
-		if (!this._inputElement) {
-			return;
+
+		const control = this.textInput?.ngControl;
+		if (control?.valueChanges) {
+			// NgControl listener
+			this._subscription = control.valueChanges
+				.pipe(startWith(control.value))
+				.subscribe((value: string) => {
+					this.textCount = value?.length || 0;
+					this.changeDetectorRef.markForCheck();
+				});
+		} else {
+			// Fallback DOM path
+			if (!this._inputElement) {
+				return;
+			}
+			this._inputListener = (e: Event) => {
+				this.textCount = (e.target as HTMLInputElement).value?.length || 0;
+				this.changeDetectorRef.detectChanges();
+			};
+			this._inputElement.addEventListener("input", this._inputListener);
 		}
-		this._inputListener = (e: Event) => {
-			this.textCount = (e.target as HTMLInputElement).value?.length || 0;
-			this.changeDetectorRef.detectChanges();
-		};
-		this._inputElement.addEventListener("input", this._inputListener);
 	}
 
 	/**
-	 * Removes the input event listener and clears the cached reference.
+	 * Removes the subscription (NgControl path) or removes the DOM listener.
+	 * Safe to call when neither is active.
 	 */
 	private _detachCounterListener(): void {
+		this._subscription?.unsubscribe();
+		this._subscription = null;
+
 		if (this._inputListener && this._inputElement) {
 			this._inputElement.removeEventListener("input", this._inputListener);
 			this._inputListener = null;

--- a/src/input/textarea-label.component.ts
+++ b/src/input/textarea-label.component.ts
@@ -12,6 +12,8 @@ import {
 	ChangeDetectorRef,
 	SimpleChanges
 } from "@angular/core";
+import { Subscription } from "rxjs";
+import { startWith } from "rxjs/operators";
 
 import { TextArea } from "./text-area.directive";
 
@@ -231,7 +233,7 @@ export class TextareaLabelComponent implements AfterViewInit, OnChanges, OnDestr
 	 */
 	@Input() decorator: TemplateRef<any>;
 
-	//  Tracks current character / word count for the counter display.
+	// Tracks current character / word count for the counter display.
 	textCount = 0;
 
 	// @ts-ignore
@@ -244,7 +246,11 @@ export class TextareaLabelComponent implements AfterViewInit, OnChanges, OnDestr
 
 	// Cached reference to the textarea element, set once in ngAfterViewInit.
 	private _textareaElement: HTMLTextAreaElement | null = null;
-	// Cached listener so it can be removed precisely (avoids anonymous-function leak)
+
+	// RxJS subscription used when NgControl is available (template-driven & reactive forms).
+	private _subscription: Subscription | null = null;
+
+	// Fallback DOM listener used only when no NgControl is present (plain textarea).
 	private _inputListener: ((e: Event) => void) | null = null;
 
 	/**
@@ -292,7 +298,6 @@ export class TextareaLabelComponent implements AfterViewInit, OnChanges, OnDestr
 
 	/**
 	 * Attach/remove listener and seed `textCount` from the textarea's current value.
-	 * @param changes
 	 */
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.enableCounter && !changes.enableCounter.firstChange) {
@@ -341,27 +346,49 @@ export class TextareaLabelComponent implements AfterViewInit, OnChanges, OnDestr
 	}
 
 	/**
-	 * Attaches the input event listener, ensuring it is never added twice.
+	 * Attaches the counter listener, listen for either ngControl or native DOM input
+	 * event listener
 	 */
 	private _attachCounterListener(): void {
 		this._detachCounterListener();
-		if (!this._textareaElement) {
-			return;
-		}
-		this._inputListener = (e: Event) => {
-			const el = e.target as HTMLTextAreaElement;
-			// Word-mode enforcement: clamp value to maxCount words on each input so
-			// the textarea never holds more words than allowed.  Character mode relies
-			// on the native `maxlength` attribute set by the developer.
-			if (this.counterMode === "word" && this.maxCount != null) {
-				const clamped = this._truncateToWordLimit(el.value || "", this.maxCount);
-				if (clamped !== el.value) {
-					el.value = clamped;
-				}
+
+		const control = this.textArea?.ngControl;
+		if (control?.valueChanges) {
+			// NgControl listener
+			this._subscription = control.valueChanges
+				.pipe(startWith(control.value))
+				.subscribe((value: string) => {
+					const raw = value || "";
+
+					if (this.counterMode === "word" && this.maxCount != null) {
+						const clamped = this._truncateToWordLimit(raw, this.maxCount);
+						if (clamped !== raw) {
+							// Write back through the control so the form model stays in sync.
+							// emitEvent false to avoid infinite loop
+							control?.control?.setValue(clamped, { emitEvent: false });
+						}
+					}
+
+					this.textCount = this._countValue(raw);
+					this.changeDetectorRef.markForCheck();
+				});
+		} else {
+			// Fallback DOM path
+			if (!this._textareaElement) {
+				return;
 			}
-			this.textCount = this._countValue(el.value || "");
-		};
-		this._textareaElement.addEventListener("input", this._inputListener);
+			this._inputListener = (e: Event) => {
+				const el = e.target as HTMLTextAreaElement;
+				if (this.counterMode === "word" && this.maxCount != null) {
+					const clamped = this._truncateToWordLimit(el.value || "", this.maxCount);
+					if (clamped !== el.value) {
+						el.value = clamped;
+					}
+				}
+				this.textCount = this._countValue(el.value || "");
+			};
+			this._textareaElement.addEventListener("input", this._inputListener);
+		}
 	}
 
 	/**
@@ -386,11 +413,14 @@ export class TextareaLabelComponent implements AfterViewInit, OnChanges, OnDestr
 		return wordsSeen < limit ? value : value.slice(0, cutIndex);
 	}
 
-
 	/**
-	 * Removes the input event listener and clears the cached reference.
+	 * Removes the subscription (NgControl path) and removes the DOM listener
+	 * (fallback path). Safe to call when neither is active.
 	 */
 	private _detachCounterListener(): void {
+		this._subscription?.unsubscribe();
+		this._subscription = null;
+
 		if (this._inputListener && this._textareaElement) {
 			this._textareaElement.removeEventListener("input", this._inputListener);
 			this._inputListener = null;

--- a/src/input/textarea.stories.ts
+++ b/src/input/textarea.stories.ts
@@ -6,12 +6,19 @@ import { AILabelModule } from "../ai-label";
 import { ButtonModule } from "../button";
 import { IconModule } from "../icon";
 import { AI_LABEL_INNER, AI_LABEL_STORY_STYLES } from "../storybook/ai-label-story-shared";
+import { FormsModule } from "@angular/forms";
 
 export default {
 	title: "Components/Input/Text area",
 	decorators: [
 		moduleMetadata({
-			imports: [InputModule, AILabelModule, ButtonModule, IconModule]
+			imports: [
+				InputModule,
+				AILabelModule,
+				ButtonModule,
+				IconModule,
+				FormsModule
+			]
 		})
 	],
 	args: {
@@ -30,7 +37,7 @@ export default {
 		readonly: false,
 		fluid: false,
 		skeleton: false,
-		enableCounter: false,
+		enableCounter: true,
 		maxCount: 500,
 		counterMode: "character"
 	},
@@ -76,6 +83,7 @@ const Template = (args) => ({
 			[rows]="rows"
 			[cols]="cols"
 			[readonly]="readonly"
+			style="width: 100%"
 			aria-label="textarea"></textarea>
 		</cds-textarea-label>
 	`


### PR DESCRIPTION
Automatically update counter when value is set using template-drive/Reactive form for both text input & textarea.

#### Changelog

**New**

* TextArea & TextInput directives now inject `NgControl` optionally

**Changed**

* Subscribe to NgControl subscription OR listen for native change event